### PR TITLE
Feat: 관리자 로그인 회원가입에 JWT 토큰 인증 방식 적용- #31

### DIFF
--- a/talkPick-admin/src/main/java/talkPick/adapter/in/AdminCommandController.java
+++ b/talkPick-admin/src/main/java/talkPick/adapter/in/AdminCommandController.java
@@ -2,10 +2,7 @@ package talkPick.adapter.in;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import talkPick.adapter.in.dto.AdminReqDTO;
 import talkPick.adapter.out.dto.AdminResDTO;
 import talkPick.port.in.AdminCommandUseCase;
@@ -30,5 +27,10 @@ public class AdminCommandController {
     @Operation(summary = "관리자 로그인", description = "POST")
     public JwtResDTO.Login adminLogin(@RequestBody @Valid AdminReqDTO.Login login, JwtResDTO.Login jwtResDTO) {
         return authCommandUseCase.login(login, jwtResDTO);
+    }
+
+    @GetMapping("")
+    public AdminResDTO.Test test() {
+        return new AdminResDTO.Test("성공!!");
     }
 }

--- a/talkPick-admin/src/main/java/talkPick/adapter/out/dto/AdminResDTO.java
+++ b/talkPick-admin/src/main/java/talkPick/adapter/out/dto/AdminResDTO.java
@@ -18,4 +18,8 @@ public class AdminResDTO {
             long id,
             String email
     ){}
+
+    public record Test (
+            String message
+    ) {}
 }

--- a/talkPick-admin/src/main/java/talkPick/domain/Admin.java
+++ b/talkPick-admin/src/main/java/talkPick/domain/Admin.java
@@ -7,7 +7,6 @@ import talkPick.model.BaseTime;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Getter
 @Entity

--- a/talkPick-auth/build.gradle
+++ b/talkPick-auth/build.gradle
@@ -6,7 +6,10 @@ dependencies {
     //security
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'

--- a/talkPick-auth/src/main/java/talkPick/security/SecurityConfig.java
+++ b/talkPick-auth/src/main/java/talkPick/security/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
                                 authorizationManagerRequestMatcherRegistry
                                         .requestMatchers(whiteList).permitAll()
                                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                                        .requestMatchers("/api/v1/admin/**").hasAuthority("ADMIN")
                                         .anyRequest()
                                         .authenticated())
                 .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class) // CorsFilter 추가

--- a/talkPick-auth/src/main/java/talkPick/security/filter/TokenAuthentication.java
+++ b/talkPick-auth/src/main/java/talkPick/security/filter/TokenAuthentication.java
@@ -1,8 +1,10 @@
 package talkPick.security.filter;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -22,7 +24,7 @@ public class TokenAuthentication implements Authentication {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.emptyList();
+        return List.of(new SimpleGrantedAuthority(role));
     }
 
     @Override

--- a/talkPick-auth/src/main/java/talkPick/security/jwt/util/JwtProvider.java
+++ b/talkPick-auth/src/main/java/talkPick/security/jwt/util/JwtProvider.java
@@ -3,6 +3,7 @@ package talkPick.security.jwt.util;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import talkPick.error.ErrorCode;
+import talkPick.security.jwt.JwtProperties;
 import talkPick.security.jwt.dto.JwtResDTO;
 
 @RequiredArgsConstructor

--- a/talkPick-auth/src/test/java/talkPick/application/JwtIntergrationTest.java
+++ b/talkPick-auth/src/test/java/talkPick/application/JwtIntergrationTest.java
@@ -1,18 +1,36 @@
 package talkPick.application;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import talkPick.security.filter.JwtAuthenticationFilter;
+import talkPick.security.filter.TokenAuthentication;
 import talkPick.security.jwt.JwtProperties;
 import talkPick.security.jwt.dto.JwtResDTO;
+import talkPick.security.jwt.repository.RefreshTokenRepository;
 import talkPick.security.jwt.util.JwtGenerator;
+import talkPick.security.jwt.util.JwtProvider;
+import talkPick.security.jwt.util.RefreshTokenGenerator;
 
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 
-class JwtGeneratorTest {
-
+class JwtIntergrationTest {
     private JwtGenerator jwtGenerator;
+    private RefreshTokenGenerator refreshTokenGenerator;
+    private JwtProvider jwtProvider;
 
     @BeforeEach
     void setUp() {
@@ -21,6 +39,11 @@ class JwtGeneratorTest {
         jwtProperties.setSecret("this-is-talk-pick-jwt-test-secret-key");
 
         jwtGenerator = new JwtGenerator(jwtProperties);
+
+        RefreshTokenRepository refreshTokenRepository = mock(RefreshTokenRepository.class);
+        refreshTokenGenerator = new RefreshTokenGenerator(refreshTokenRepository);
+
+        jwtProvider = new JwtProvider(jwtGenerator, refreshTokenGenerator);
     }
 
     @Test
@@ -28,13 +51,47 @@ class JwtGeneratorTest {
     void parse_role_from_jwt_token() {
         // given
         long userId = 1L;
-        String role = "USER";
+        String role = "ADMIN"; // ADMIN role
         JwtResDTO.AccessToken tokenDto = jwtGenerator.generateAccessToken(userId, role);
 
         // when
-        Jws<Claims> claims = jwtGenerator.parseToken(tokenDto.accessToken());
+        Jws<Claims> jws = jwtGenerator.parseToken(tokenDto.accessToken());
+        Claims claims = jws.getBody();
 
         // then
-        assertEquals(role, claims.getBody().get("role"));
+        assertEquals(role, claims.get("role")); // ADMIN role 파싱 검증
+    }
+
+    @Test
+    @DisplayName("JwtAuthenticationFilter가 SecurityContext에 인증 객체를 저장하는지 검증")
+    void jwt_authentication_filter_sets_authentication() throws ServletException, IOException {
+        // given
+        long userId = 123L;
+        String role = "DEV";
+        String token = jwtGenerator.generateAccessToken(userId, role).accessToken();
+
+        var request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+
+        var response = new MockHttpServletResponse();
+        var filterChain = mock(FilterChain.class);
+
+        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtProvider);
+
+        // when
+        jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+        // then
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(authentication);
+        assertTrue(authentication instanceof TokenAuthentication);
+        assertEquals(userId, ((TokenAuthentication) authentication).getPrincipal());
+        assertEquals(role, ((TokenAuthentication) authentication).getAuthorities().stream().findFirst().get().getAuthority());
+
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#31

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- `admin` 모듈에서 `auth` 모듈을 사용하는 관리자 로그인, 회원가입 기능을 AuthCommandService, AuthQueryService로 구분하여 구현했습니다.
- 관리자 로그인 및 회원가입에 JWT 인증 방식을 적용했습니다.
(아래는 로그인 요청에 대한 정상 응답 예시입니다.)
<img width="1060" alt="스크린샷 2025-04-10 오전 12 41 06" src="https://github.com/user-attachments/assets/074f5cd0-f284-4807-9713-2031d7682ab3" />

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 테스트는 `auth` 모듈에 JwtIntergrationTest 클래스 참고해주세요.
- /admin/login, /admin/signup은 별도의 인가 없이 접근 가능하도록 SecurityConfig의 whitelist에 등록했습니다.
- 이후에 `admin` 모듈에서 `auth` 모듈 을 사용하지 않는 비즈니스 로직은 adminCommand/QueryService에 구현할 예정입니다.

## 📟 관련 이슈
- Resolved: #31 
