### PR TITLE
[Refactor] 카카오 로그인 API 개선

### DIFF
--- a/src/main/java/talkPick/domain/member/adapter/in/KakaoAuthController.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/KakaoAuthController.java
@@ -53,7 +53,7 @@ public class KakaoAuthController {
 
 
     //카카오 회원가입
-    @GetMapping("/oauth/kakao/authorize")
+    @GetMapping("/api/v1/oauth/kakao/authorize")
     public void joinKakaoMember(HttpServletResponse response) throws IOException {
         // 카카오 로그인 URL 생성
         String kakaoAuthUrl = "https://kauth.kakao.com/oauth/authorize"
@@ -99,7 +99,7 @@ public class KakaoAuthController {
             response.sendRedirect("/api/v1/topic");
         } else {
             log.info("신규 회원 - 추가 정보 입력 페이지로 리다이렉트");
-            response.sendRedirect("/mbti-form.html");
+            response.sendRedirect("/api/v1/topic/additional");
         }
     }
 

--- a/src/main/java/talkPick/domain/member/adapter/in/MemberCommandController.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/MemberCommandController.java
@@ -78,19 +78,20 @@ public class MemberCommandController {
 
     //mbti 입력 페이지
     @GetMapping("/topic/additional")
-    public String showMbtiForm(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    public void showMbtiForm(HttpServletRequest request, HttpServletResponse response) throws IOException {
         log.info("mbti 입력 페이지");
         HttpSession session = request.getSession(false);
 
         if (session == null || session.getAttribute("userInfo") == null) {
             log.error("세션이 만료되었거나 카카오 사용자 정보가 없습니다.");
-            return "redirect:/oauth/kakao/authorize"; // 스프링 MVC의 리다이렉트 방식
+            response.sendRedirect("/oauth/kakao/authorize");
+            return;
         }
 
         KakaoUserInfo userInfo = (KakaoUserInfo) session.getAttribute("userInfo");
 
-        // 뷰 이름 반환
-        return "mbti-form";
+        // 뷰로 리다이렉트
+        response.sendRedirect("/mbti-form.html");
     }
 
     // mbti 수정

--- a/src/main/java/talkPick/global/security/model/WhiteList.java
+++ b/src/main/java/talkPick/global/security/model/WhiteList.java
@@ -7,7 +7,7 @@ public final class WhiteList {
             "/api/v1/admin/signup",
             "/api/v1/admin/login",
             "/api/v1/member/login",
-            "/oauth/kakao/authorize",
+            "/api/v1/oauth/kakao/authorize",
             "/api/v1/topic/kakao",
             "/api/v1/topic/additional",
             "/api/v1/topic",


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **Branch**
- Refactor/#143

👷 **Work Done**
- 카카오 로그인 요청 url `/oauth/kakao/authorize` -> `/api/v1/oauth/kakao/authorize` 변경 및 WhiteList 수정 완료
- mbti 추가 입력 폼 연결 방식 수정
  ```java
  response.sendRedirect("/api/v1/topic/additional");
   ```
  기존엔 `mbti-form.html`로 바로 연결되는 방식이었는데 프론트 측 연결을 위해 수정

최종 카카오 로그인 플로우

1. **카카오 로그인 시작**
    - `GET /api/v1/oauth/kakao/authorize`
    - → 카카오 로그인 페이지로 리다이렉트

2. **카카오 인증 후 콜백**
    - 카카오에서 인가 코드(`code`)와 함께 프론트로 리다이렉트
    - 프론트는 받은 `code`를 서버의  
      `GET /api/v1/topic/kakao?code={인가코드}`  
      로 전달

3. **회원 여부에 따른 분기**
    - 서버에서 기존 회원/신규 회원 판단
    - **기존 회원**
        - 서버가 `/api/v1/topic`(메인 페이지)로 리다이렉트
        - 프론트는 메인 페이지로 이동
    - **신규 회원**
        - 서버가 `/api/v1/topic/additional`(GET)로 리다이렉트
        - 프론트는 추가 정보 입력 폼(`/mbti-form.html`)으로 이동

4. **신규 회원 추가 정보 입력**
    - 프론트에서 MBTI 등 추가 정보 입력 후  
      `POST /api/v1/topic/additional`  
      로 서버에 전송

5. **회원가입 완료 및 메인 이동**
    - 서버에서 회원 정보 저장 및 JWT 토큰 발급
    - 최종적으로 `/api/v1/topic`(GET)로 리다이렉트
    - 프론트는 메인 페이지로 이동


## 🚨 Notes

리뷰하실 때 KakaoAuthController, MemberCommandController 위주로 보시면 될 것 같습니다.