### PR TITLE
Refactor/#180

### DIFF
--- a/src/main/java/talkPick/domain/member/adapter/in/MemberCommandApi.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/MemberCommandApi.java
@@ -63,4 +63,10 @@ public interface MemberCommandApi {
     @Operation(summary = "계정 탈퇴 API", description = "계정 탈퇴 API입니다.")
     ResponseEntity<ResultResponse<Void>> deleteMember(
             @RequestHeader(value = "Authorization", required = false) String authorization);
+
+    @PatchMapping("/topic-results")
+    @Operation(summary = "캘린더 조회 토픽 코멘트 수정 API", description = "캘린더 조회 토픽의 코멘트를 수정하는 API입니다.")
+    ResponseEntity<ResultResponse<Void>> changeComment(
+            @RequestHeader(value = "Authorization", required = false) String authorization
+    );
 }

--- a/src/main/java/talkPick/domain/member/adapter/in/MemberCommandApi.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/MemberCommandApi.java
@@ -67,6 +67,7 @@ public interface MemberCommandApi {
     @PatchMapping("/topic-results")
     @Operation(summary = "캘린더 조회 토픽 코멘트 수정 API", description = "캘린더 조회 토픽의 코멘트를 수정하는 API입니다.")
     ResponseEntity<ResultResponse<Void>> changeComment(
-            @RequestHeader(value = "Authorization", required = false) String authorization
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @Valid @RequestBody MemberReqDto.TopicResultCommentChangeRequest request
     );
 }

--- a/src/main/java/talkPick/domain/member/adapter/in/MemberCommandController.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/MemberCommandController.java
@@ -99,7 +99,9 @@ public class MemberCommandController implements MemberCommandApi {
     }
 
     @Override
-    public ResponseEntity<ResultResponse<Void>> changeComment(String authorization) {
+    public ResponseEntity<ResultResponse<Void>> changeComment(
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @Valid @RequestBody MemberReqDto.TopicResultCommentChangeRequest request) {
         return null;
     }
 

--- a/src/main/java/talkPick/domain/member/adapter/in/MemberCommandController.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/MemberCommandController.java
@@ -102,7 +102,8 @@ public class MemberCommandController implements MemberCommandApi {
     public ResponseEntity<ResultResponse<Void>> changeComment(
             @RequestHeader(value = "Authorization", required = false) String authorization,
             @Valid @RequestBody MemberReqDto.TopicResultCommentChangeRequest request) {
-        return null;
+        memberCommandUseCase.TopicResultCommentChange(authorization, request);
+        return ResponseEntity.ok(ResultResponse.success(null));
     }
 
 

--- a/src/main/java/talkPick/domain/member/adapter/in/MemberCommandController.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/MemberCommandController.java
@@ -98,6 +98,10 @@ public class MemberCommandController implements MemberCommandApi {
         return ResponseEntity.ok(ResultResponse.success(null));
     }
 
+    @Override
+    public ResponseEntity<ResultResponse<Void>> changeComment(String authorization) {
+        return null;
+    }
 
 
 }

--- a/src/main/java/talkPick/domain/member/adapter/in/MemberQueryApi.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/MemberQueryApi.java
@@ -11,6 +11,7 @@ import talkPick.domain.member.adapter.out.dto.MemberResDto;
 import talkPick.global.response.CursorPageResponse;
 import talkPick.global.response.ResultResponse;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @RequestMapping("/api/v1/members")
@@ -24,12 +25,12 @@ public interface MemberQueryApi {
             @RequestParam(value = "size", defaultValue = "6") @Parameter(description = "페이지 크기 (1 이상)", schema = @Schema(minimum = "1")) int size
             );
 
-//    @GetMapping("/topic-results")
-//    @Operation(summary = "회원 토픽 결과 조회 API", description = "특정 날짜의 회원 토픽 결과를 조회하는 API입니다.")
-//    ResponseEntity<ResultResponse<CursorPageResponse<MemberResDto.MemberTopicResultResDto>>> getMemberTopicResults(
-//            @RequestHeader(value = "Authorization", required = false) String authorization,
-//            @Parameter(description = "조회할 날짜 (yyyy-MM-dd)") @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
-//            );
+    @GetMapping("/topic-results")
+    @Operation(summary = "회원 토픽 결과 캘린더 조회 API", description = "특정 날짜의 회원 토픽 결과를 조회하는 API입니다.")
+    ResponseEntity<ResultResponse<CursorPageResponse<MemberResDto.MemberTopicResultResDto>>> getMemberTopicResults(
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @Parameter(description = "조회할 날짜 (yyyy-MM-dd)") @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+            );
 
     @GetMapping("/me")
     @Operation(summary = "마이페이지 프로필 조회 API", description = "회원의 프로필 정보와 통계를 조회하는 API입니다.")

--- a/src/main/java/talkPick/domain/member/adapter/in/MemberQueryApi.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/MemberQueryApi.java
@@ -26,10 +26,12 @@ public interface MemberQueryApi {
             );
 
     @GetMapping("/topic-results")
-    @Operation(summary = "회원 토픽 결과 캘린더 조회 API", description = "특정 날짜의 회원 토픽 결과를 조회하는 API입니다.")
+    @Operation(summary = "회원 토픽 결과 캘린더 조회 API", description = "특정 날짜의 회원 토픽 결과를 커서 페이징으로 조회하는 API입니다.")
     ResponseEntity<ResultResponse<CursorPageResponse<MemberResDto.MemberTopicResultResDto>>> getMemberTopicResults(
             @RequestHeader(value = "Authorization", required = false) String authorization,
-            @Parameter(description = "조회할 날짜 (yyyy-MM-dd)") @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+            @Parameter(description = "조회할 날짜 (yyyy-MM-dd)") @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam(value = "cursor", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDateTime cursor,
+            @RequestParam(value = "size", defaultValue = "6") @Parameter(description = "페이지 크기 (1 이상)", schema = @Schema(minimum = "1")) int size
             );
 
     @GetMapping("/me")

--- a/src/main/java/talkPick/domain/member/adapter/in/MemberQueryController.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/MemberQueryController.java
@@ -37,9 +37,12 @@ public class MemberQueryController implements MemberQueryApi {
     @Override
     public ResponseEntity<ResultResponse<CursorPageResponse<MemberResDto.MemberTopicResultResDto>>> getMemberTopicResults(
             @RequestHeader(value = "Authorization", required = false) String authorization,
-            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam(value = "cursor", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDateTime cursor,
+            @RequestParam(value = "size", defaultValue = "6") int size
             ) {
-        memberQueryUseCase.getMemberTopicResultsByCreatedDate(authorization, date);
-        return null;
+        CursorPageResponse<MemberResDto.MemberTopicResultResDto> result =
+                memberQueryUseCase.getMemberTopicResultsByCreatedDate(authorization, date, cursor, size);
+        return ResponseEntity.ok(ResultResponse.success(result));
     }
 }

--- a/src/main/java/talkPick/domain/member/adapter/in/MemberQueryController.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/MemberQueryController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import talkPick.domain.member.adapter.out.dto.MemberResDto;
 import talkPick.domain.member.port.in.MemberQueryUseCase;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import talkPick.global.response.CursorPageResponse;
 import talkPick.global.response.ResultResponse;
@@ -33,12 +34,12 @@ public class MemberQueryController implements MemberQueryApi {
     }
 
 
-//    @Override
-//    public ResponseEntity<ResultResponse<CursorPageResponse<MemberResDto.MemberTopicResultResDto>>> getMemberTopicResults(
-//            @RequestHeader(value = "Authorization", required = false) String authorization,
-//            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
-//            ) {
-//        memberQueryUseCase.getMemberTopicResultsByCreatedDate(authorization, date);
-//        return null;
-//    }
+    @Override
+    public ResponseEntity<ResultResponse<CursorPageResponse<MemberResDto.MemberTopicResultResDto>>> getMemberTopicResults(
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+            ) {
+        memberQueryUseCase.getMemberTopicResultsByCreatedDate(authorization, date);
+        return null;
+    }
 }

--- a/src/main/java/talkPick/domain/member/adapter/in/dto/MemberReqDto.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/dto/MemberReqDto.java
@@ -83,4 +83,15 @@ public class MemberReqDto {
         @NotNull(message = "비밀번호는 필수입니다.")
         private String password;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class TopicResultCommentChangeRequest {
+        @NotNull(message = "히스토리 ID는 필수입니다.")
+        private Long memberTopicHistoryId;
+        @Size(max = 100, message = "코멘트는 최대 100자입니다.")
+        private String comment;
+    }
 }

--- a/src/main/java/talkPick/domain/member/adapter/out/dto/MemberResDto.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/dto/MemberResDto.java
@@ -67,7 +67,8 @@ public class MemberResDto {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
-    public class MemberTopicResultResDto {
+    public static class MemberTopicResultResDto {
+        private Long id; // 히스토리 ID (MemberTopicHistory)
         private String comment; // 한 줄 코멘트
         private List<Keyword> topicKeyword; // 토픽 키워드
         private LocalDateTime createdDate; // 대화 날짜

--- a/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTermJpaRepository.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTermJpaRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 public interface MemberTermJpaRepository extends JpaRepository<MemberTerm, Long> {
     // 특정 약관 및 유저의 동의 상태 조회
-    Optional<MemberTerm> findByMemberIdAndTerm(Long memberId, Term term);
+    Optional<MemberTerm> findByMemberIdAndTermId(Long memberId, Long termId);
 }

--- a/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicResultJpaRepository.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicResultJpaRepository.java
@@ -3,5 +3,8 @@ package talkPick.domain.member.adapter.out.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import talkPick.domain.topic.domain.member.MemberTopicResult;
 
+import java.util.Optional;
+
 public interface MemberTopicResultJpaRepository extends JpaRepository<MemberTopicResult, Long> {
+    Optional<MemberTopicResult> findByMemberTopicHistoryId(Long memberTopicHistoryId);
 }

--- a/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicResultQuerydslRepository.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicResultQuerydslRepository.java
@@ -1,17 +1,63 @@
 package talkPick.domain.member.adapter.out.repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Repository;
+import talkPick.domain.member.adapter.out.dto.MemberResDto;
+import talkPick.domain.member.domain.Member;
 import talkPick.domain.member.port.out.MemberTopicResultQueryRepositoryPort;
+import talkPick.domain.topic.domain.*;
+import talkPick.domain.topic.domain.member.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.querydsl.core.group.GroupBy.*;
 
 @Repository
 public class MemberTopicResultQuerydslRepository implements MemberTopicResultQueryRepositoryPort {
     private final JPAQueryFactory queryFactory;
-    
+
     public MemberTopicResultQuerydslRepository(EntityManager em) {
         this.queryFactory = new JPAQueryFactory(em);
     }
 
+    @Override
+    public List<MemberResDto.MemberTopicResultResDto> findMemberTopicResults(Member member, LocalDate date, LocalDateTime cursor, int size) {
+        QMemberTopicHistory mth = QMemberTopicHistory.memberTopicHistory;
+        QMemberTopicResult mtr = QMemberTopicResult.memberTopicResult;
+        QTopicKeyword tk = QTopicKeyword.topicKeyword;
+
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime nextDayStart = date.plusDays(1).atStartOfDay();
+
+        // 커서 조건: cursor 이전(createdDate)만 조회
+        // createdDate가 동일할 경우를 대비해 id를 세컨더리 정렬 키로 사용
+        return queryFactory
+                .from(mth)
+                .leftJoin(mtr).on(mtr.id.eq(mth.member_topic_result_id))
+                .leftJoin(tk).on(tk.topicId.eq(mth.topicId))
+                .where(
+                        mth.memberId.eq(member.getId())
+                                .and(mth.member_topic_result_id.isNotNull())
+                                .and(mth.createdDate.goe(startOfDay))
+                                .and(mth.createdDate.lt(nextDayStart))
+                                .and(cursor != null ? mth.createdDate.lt(cursor) : null)
+                )
+                .orderBy(mth.createdDate.desc(), mth.id.desc())
+                .limit(size + 1)
+                .transform(groupBy(mth.id).list(
+                        Projections.constructor(
+                                MemberResDto.MemberTopicResultResDto.class,
+                                mth.id,
+                                mtr.comment,
+                                list(tk.keyword),
+                                mth.createdDate
+                        )
+                ));
+    }
 }

--- a/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicResultQuerydslRepository.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicResultQuerydslRepository.java
@@ -13,57 +13,5 @@ public class MemberTopicResultQuerydslRepository implements MemberTopicResultQue
     public MemberTopicResultQuerydslRepository(EntityManager em) {
         this.queryFactory = new JPAQueryFactory(em);
     }
-//
-//    QRandom r = QRandom.random;
-//    QTopic t = QTopic.topic;
-//    QTopicKeyword tk = QTopicKeyword.topicKeyword;
-//    QMemberTopicHistory mth = QMemberTopicHistory.memberTopicHistory;
-//    QRandomTopicHistory rth = QRandomTopicHistory.randomTopicHistory;
-//
-//    @Override
-//    public List<MemberResDto.MemberTopicResultResDto> findMemberTopicResults(Member member, LocalDate date) {
-//        // 일반 토픽 대화 기록 조회 (MemberTopicHistory)
-//        List<MemberResDto.MemberTopicResultResDto> memberTopicResults = queryFactory
-//                .select(Projections.constructor(MemberResDto.MemberTopicResultResDto.class,
-//                        memberTopicResult.comment,
-//                        tk.keyword,
-//                        mth.createdDate))
-//                .from(mth)
-//                .leftJoin(memberTopicResult).on(
-//                        memberTopicResult.member.eq(member)
-//                        .and(memberTopicResult.id.eq(mth.id))
-//                )
-//                .innerJoin(t).on(mth.topic.eq(t))
-//                .innerJoin(tk).on(tk.topicId.eq(t.id))
-//                .where(mth.member.eq(member)
-//                        .and(mth.createdDate.goe(date.atStartOfDay()))
-//                        .and(mth.createdDate.lt(date.plusDays(1).atStartOfDay())))
-//                .orderBy(mth.createdDate.asc())
-//                .fetch();
-//
-//        // 랜덤 토픽 대화 기록 조회 (RandomTopicHistory)
-//        List<MemberResDto.MemberTopicResultResDto> randomTopicResults = queryFactory
-//                .select(Projections.constructor(MemberResDto.MemberTopicResultResDto.class,
-//                        memberTopicResult.comment,
-//                        tk.keyword,
-//                        rth.startAt))
-//                .from(rth)
-//                .leftJoin(memberTopicResult).on(
-//                        memberTopicResult.member.eq(member)
-//                        .and(memberTopicResult.id.eq(rth.id))
-//                )
-//                .innerJoin(t).on(rth.topicId.eq(t.id))
-//                .innerJoin(tk).on(tk.topicId.eq(t.id))
-//                .where(rth.memberId.eq(member.getId())
-//                        .and(rth.startAt.goe(date.atStartOfDay()))
-//                        .and(rth.startAt.lt(date.plusDays(1).atStartOfDay())))
-//                .orderBy(rth.startAt.asc())
-//                .fetch();
-//
-//        // 두 결과를 합치고 날짜순으로 정렬
-//        memberTopicResults.addAll(randomTopicResults);
-//        memberTopicResults.sort((a, b) -> a.getCreatedDate().compareTo(b.getCreatedDate()));
-//
-//        return memberTopicResults;
-//    }
+
 }

--- a/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicResultQuerydslRepository.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicResultQuerydslRepository.java
@@ -13,9 +13,7 @@ import talkPick.domain.topic.domain.member.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static com.querydsl.core.group.GroupBy.*;
 

--- a/src/main/java/talkPick/domain/member/application/MemberCommandService.java
+++ b/src/main/java/talkPick/domain/member/application/MemberCommandService.java
@@ -23,6 +23,8 @@ import talkPick.global.exception.handler.MemberExceptionHandler;
 import talkPick.global.exception.handler.TermExceptionHandler;
 import talkPick.global.model.TalkPickStatus;
 import talkPick.global.security.jwt.util.JwtProvider;
+import talkPick.domain.member.adapter.out.repository.MemberTopicResultJpaRepository;
+import talkPick.domain.topic.domain.member.MemberTopicResult;
 
 import java.util.List;
 
@@ -39,6 +41,7 @@ public class MemberCommandService implements MemberCommandUseCase {
     private final MemberLoginHistoryCommandRepositoryPort memberLoginHistoryRepository;
     private final JwtProvider jwtProvider;
     private final PasswordEncoder passwordEncoder;
+    private final MemberTopicResultJpaRepository memberTopicResultJpaRepository;
 
     /**
      * 회원 프로필 수정
@@ -228,6 +231,29 @@ public class MemberCommandService implements MemberCommandUseCase {
 
         refreshTokenRepository.deleteByMemberId(findMember.getId());
         memberLoginHistoryRepository.deleteByMemberId(findMember.getId());
+    }
+
+    // 토픽 캘린더 조회 코멘트 수정
+    @Override
+    public void TopicResultCommentChange(String authorization, MemberReqDto.TopicResultCommentChangeRequest request) {
+        Long memberId = jwtProvider.getMemberId(authorization);
+
+        // 회원 조회
+        Member findMember = memberJpaRepository.findById(memberId)
+                .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
+
+        // MemberTopicResult 조회 (member_topic_history_id로 조회)
+        MemberTopicResult findMemberTopicResult = memberTopicResultJpaRepository.findByMemberTopicHistoryId(request.getMemberTopicHistoryId())
+                .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 본인의 토픽 결과인지 검증
+        if (!findMemberTopicResult.getMemberId().equals(findMember.getId())) {
+            throw new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        // 코멘트 업데이트
+        findMemberTopicResult.updateComment(request.getComment());
+        memberTopicResultJpaRepository.save(findMemberTopicResult);
     }
 
     // 회원 가입 시 필수 정보 검증

--- a/src/main/java/talkPick/domain/member/application/MemberCommandService.java
+++ b/src/main/java/talkPick/domain/member/application/MemberCommandService.java
@@ -181,7 +181,7 @@ public class MemberCommandService implements MemberCommandUseCase {
         for (Long termId : agreeTermIdList) {
             Term term = termJpaRepository.findById(termId)
                     .orElseThrow(() -> new TermExceptionHandler(ErrorCode.TERM_NOT_FOUND));
-            memberTermJpaRepository.findByMemberIdAndTerm(findMember.getId(), term)
+            memberTermJpaRepository.findByMemberIdAndTermId(findMember.getId(), term.getId())
                     .ifPresentOrElse(
                             mt -> mt.updateIsAgree(true),
                             () -> memberTermJpaRepository.save(MemberConverter.toMemberTerm(findMember, term, true))
@@ -192,7 +192,7 @@ public class MemberCommandService implements MemberCommandUseCase {
         for (Long termId : disagreeTermIdList) {
             Term term = termJpaRepository.findById(termId)
                     .orElseThrow(() -> new TermExceptionHandler(ErrorCode.TERM_NOT_FOUND));
-            memberTermJpaRepository.findByMemberIdAndTerm(findMember.getId(), term)
+            memberTermJpaRepository.findByMemberIdAndTermId(findMember.getId(), term.getId())
                     .ifPresentOrElse(
                             mt -> mt.updateIsAgree(false),
                             () -> memberTermJpaRepository.save(MemberConverter.toMemberTerm(findMember, term, false))

--- a/src/main/java/talkPick/domain/member/application/MemberQueryService.java
+++ b/src/main/java/talkPick/domain/member/application/MemberQueryService.java
@@ -1,6 +1,7 @@
 package talkPick.domain.member.application;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import talkPick.domain.member.adapter.out.dto.MemberResDto;
@@ -15,6 +16,7 @@ import talkPick.global.exception.handler.MemberExceptionHandler;
 import talkPick.global.response.CursorPageResponse;
 import talkPick.global.security.jwt.util.JwtProvider;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -76,13 +78,13 @@ public class MemberQueryService implements MemberQueryUseCase {
     /**
      * 특정 일자 기준 회원 토픽 캘린더 결과 조회
      */
-//    @Override
-//    public Page<MemberResDto.MemberTopicResultResDto> getMemberTopicResultsByCreatedDate(String authorization, LocalDate date) {
-//        Long memberId = jwtProvider.getMemberId(authorization);
-//
-//        Member findMember = memberJpaRepository.findById(memberId)
-//                .orElseThrow(() -> new MemberHandler(ErrorCode.MEMBER_NOT_FOUND));
-//
-//        return memberTopicResultQueryRepositoryPort.findMemberTopicResults(findMember, date);
-//    }
+    @Override
+    public CursorPageResponse<MemberResDto.MemberTopicResultResDto> getMemberTopicResultsByCreatedDate(String authorization, LocalDate date) {
+        Long memberId = jwtProvider.getMemberId(authorization);
+
+        Member findMember = memberJpaRepository.findById(memberId)
+                .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
+
+        return memberTopicResultQueryRepositoryPort.findMemberTopicResults(findMember, date);
+    }
 }

--- a/src/main/java/talkPick/domain/member/application/MemberQueryService.java
+++ b/src/main/java/talkPick/domain/member/application/MemberQueryService.java
@@ -79,12 +79,31 @@ public class MemberQueryService implements MemberQueryUseCase {
      * 특정 일자 기준 회원 토픽 캘린더 결과 조회
      */
     @Override
-    public CursorPageResponse<MemberResDto.MemberTopicResultResDto> getMemberTopicResultsByCreatedDate(String authorization, LocalDate date) {
+    public CursorPageResponse<MemberResDto.MemberTopicResultResDto> getMemberTopicResultsByCreatedDate(String authorization, LocalDate date, LocalDateTime cursor, int size) {
         Long memberId = jwtProvider.getMemberId(authorization);
 
         Member findMember = memberJpaRepository.findById(memberId)
                 .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
 
-        return memberTopicResultQueryRepositoryPort.findMemberTopicResults(findMember, date);
+        // size + 1개 조회하여 다음 페이지 존재 여부 판단
+        List<MemberResDto.MemberTopicResultResDto> items = memberTopicResultQueryRepositoryPort.findMemberTopicResults(findMember, date, cursor, size + 1);
+
+        // 다음 페이지 존재 시 마지막 데이터 제거
+        boolean hasNext = items.size() > size;
+        if (hasNext) items.remove(items.size() - 1);
+
+        // 다음 페이지 조회용 커서 생성
+        CursorPageResponse.Cursor nextCursor = null;
+        if (hasNext && !items.isEmpty()) {
+            MemberResDto.MemberTopicResultResDto last = items.get(items.size() - 1);
+            nextCursor = new CursorPageResponse.Cursor(last.getCreatedDate(), last.getId());
+        }
+
+        // 커서 기반 페이징 응답 반환
+        return CursorPageResponse.<MemberResDto.MemberTopicResultResDto>builder()
+                .items(items)
+                .hasNext(hasNext)
+                .nextCursor(nextCursor)
+                .build();
     }
 }

--- a/src/main/java/talkPick/domain/member/converter/MemberConverter.java
+++ b/src/main/java/talkPick/domain/member/converter/MemberConverter.java
@@ -85,7 +85,7 @@ public class MemberConverter {
     public static MemberTerm toMemberTerm(Member member, Term term, Boolean isAgree) {
         return MemberTerm.builder()
                 .memberId(member.getId())
-                .term(term)
+                .termId(term.getId())
                 .isAgree(isAgree)
                 .build();
     }

--- a/src/main/java/talkPick/domain/member/domain/mapping/MemberTerm.java
+++ b/src/main/java/talkPick/domain/member/domain/mapping/MemberTerm.java
@@ -5,7 +5,6 @@ import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
-import talkPick.domain.term.domain.Term;
 import talkPick.global.model.BaseTime;
 
 
@@ -33,12 +32,12 @@ public class MemberTerm extends BaseTime {
     )
     private Long memberId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(
+    @Column(
             name = "term_id",
+            nullable = false,
             columnDefinition = "BIGINT COMMENT '약관 PK (Foreign Key)'"
     )
-    private Term term;
+    private Long termId;
 
     @Column(
             nullable = false,

--- a/src/main/java/talkPick/domain/member/port/in/MemberCommandUseCase.java
+++ b/src/main/java/talkPick/domain/member/port/in/MemberCommandUseCase.java
@@ -14,4 +14,5 @@ public interface MemberCommandUseCase {
     MemberResDto.TermAgreementResponse termAgreement(String authorization, MemberReqDto.TermAgreementRequest request);
     void logout(String authorization);
     void delete(String authorization);
+    void TopicResultCommentChange(String authorization, MemberReqDto.TopicResultCommentChangeRequest request);
 }

--- a/src/main/java/talkPick/domain/member/port/in/MemberQueryUseCase.java
+++ b/src/main/java/talkPick/domain/member/port/in/MemberQueryUseCase.java
@@ -1,13 +1,15 @@
 package talkPick.domain.member.port.in;
 
+import org.springframework.data.domain.Page;
 import talkPick.domain.member.adapter.out.dto.MemberResDto;
 import talkPick.global.response.CursorPageResponse;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public interface MemberQueryUseCase {
     CursorPageResponse<MemberResDto.MemberLikedTopicResDto> getMemberLikedTopics(String authorization, LocalDateTime cursor, int size);
-//    Page<MemberResDto.MemberTopicResultResDto> getMemberTopicResultsByCreatedDate(String authorization, LocalDate date);
+    CursorPageResponse<MemberResDto.MemberTopicResultResDto> getMemberTopicResultsByCreatedDate(String authorization, LocalDate date);
     MemberResDto.ProfileResponse getProfile(String authorization);
 
 }

--- a/src/main/java/talkPick/domain/member/port/in/MemberQueryUseCase.java
+++ b/src/main/java/talkPick/domain/member/port/in/MemberQueryUseCase.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 
 public interface MemberQueryUseCase {
     CursorPageResponse<MemberResDto.MemberLikedTopicResDto> getMemberLikedTopics(String authorization, LocalDateTime cursor, int size);
-    CursorPageResponse<MemberResDto.MemberTopicResultResDto> getMemberTopicResultsByCreatedDate(String authorization, LocalDate date);
+    CursorPageResponse<MemberResDto.MemberTopicResultResDto> getMemberTopicResultsByCreatedDate(String authorization, LocalDate date, LocalDateTime cursor, int size);
     MemberResDto.ProfileResponse getProfile(String authorization);
 
 }

--- a/src/main/java/talkPick/domain/member/port/out/MemberTopicResultQueryRepositoryPort.java
+++ b/src/main/java/talkPick/domain/member/port/out/MemberTopicResultQueryRepositoryPort.java
@@ -1,6 +1,12 @@
 package talkPick.domain.member.port.out;
 
+import talkPick.domain.member.adapter.out.dto.MemberResDto;
+import talkPick.domain.member.domain.Member;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface MemberTopicResultQueryRepositoryPort {
-//    List<MemberResDto.MemberTopicResultResDto> findMemberTopicResults(Member member, LocalDate date);
+    List<MemberResDto.MemberTopicResultResDto> findMemberTopicResults(Member member, LocalDate date, LocalDateTime cursor, int size);
 }
 

--- a/src/main/java/talkPick/domain/topic/domain/member/MemberTopicHistory.java
+++ b/src/main/java/talkPick/domain/topic/domain/member/MemberTopicHistory.java
@@ -30,7 +30,6 @@ public class MemberTopicHistory extends BaseTime {
     private Long topicId;
 
     @Column(name = "member_topic_result_id",
-            nullable = false,
             columnDefinition = "BIGINT COMMENT 'MemberTopicResult ID'")
     private Long member_topic_result_id;
 

--- a/src/main/java/talkPick/domain/topic/domain/member/MemberTopicHistory.java
+++ b/src/main/java/talkPick/domain/topic/domain/member/MemberTopicHistory.java
@@ -2,8 +2,6 @@ package talkPick.domain.topic.domain.member;
 
 import jakarta.persistence.*;
 import lombok.*;
-import talkPick.domain.member.domain.Member;
-import talkPick.domain.topic.domain.Topic;
 import talkPick.domain.topic.domain.type.TopicType;
 import talkPick.global.model.BaseTime;
 
@@ -16,20 +14,25 @@ import talkPick.global.model.BaseTime;
 public class MemberTopicHistory extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false, columnDefinition = "BIGINT COMMENT '기본 키'")
+    @Column(name = "member_topic_history_id", nullable = false, columnDefinition = "BIGINT COMMENT '기본 키'")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false, columnDefinition = "BIGINT COMMENT '회원 ID'")
-    private Member member;
+    @Column(
+            name = "member_id",
+            nullable = false,
+            columnDefinition = "BIGINT COMMENT '회원 PK (Foreign Key)'"
+    )
+    private Long memberId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "topic_id", nullable = false, columnDefinition = "BIGINT COMMENT 'Topic ID'")
-    private Topic topic;
+    @Column(name = "topic_id",
+            nullable = false,
+            columnDefinition = "BIGINT COMMENT 'Topic ID'")
+    private Long topicId;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_topic_result_id")
-    private MemberTopicResult memberTopicResult;
+    @Column(name = "member_topic_result_id",
+            nullable = false,
+            columnDefinition = "BIGINT COMMENT 'MemberTopicResult ID'")
+    private Long member_topic_result_id;
 
     @Column(name = "talk_time", nullable = false, columnDefinition = "BIGINT COMMENT '토크 시간(ms)'")
     private long talkTime;
@@ -44,13 +47,13 @@ public class MemberTopicHistory extends BaseTime {
     @Column(name = "topic_type", nullable = false, length = 50, columnDefinition = "VARCHAR(50) COMMENT 'Topic 유형'")
     private TopicType topicType;
 
-    public void setMember(Member member) {
-        this.member = member;
+    public void setMember(Long memberId) {
+        this.memberId = memberId;
     }
-    public void setTopic(Topic topic) {
-        this.topic = topic;
+    public void setTopic(Long topicId) {
+        this.topicId = topicId;
     }
-    public static MemberTopicHistory of(Member member, Topic topic, TopicType topicType,
+    public static MemberTopicHistory of(Long memberId, Long topicId, TopicType topicType,
                                          int sequence, final long talkTime) {
         MemberTopicHistory memberTopicHistory = MemberTopicHistory.builder()
                 .talkTime(talkTime)
@@ -59,8 +62,8 @@ public class MemberTopicHistory extends BaseTime {
                 .sequence(sequence)
                 .build();
 
-        memberTopicHistory.setMember(member);
-        memberTopicHistory.setTopic(topic);
+        memberTopicHistory.setMember(memberId);
+        memberTopicHistory.setTopic(topicId);
         return memberTopicHistory;
     }
 }

--- a/src/main/java/talkPick/domain/topic/domain/member/MemberTopicHistory.java
+++ b/src/main/java/talkPick/domain/topic/domain/member/MemberTopicHistory.java
@@ -31,7 +31,6 @@ public class MemberTopicHistory extends BaseTime {
     @JoinColumn(name = "member_topic_result_id")
     private MemberTopicResult memberTopicResult;
 
-
     @Column(name = "talk_time", nullable = false, columnDefinition = "BIGINT COMMENT '토크 시간(ms)'")
     private long talkTime;
 

--- a/src/main/java/talkPick/domain/topic/domain/member/MemberTopicResult.java
+++ b/src/main/java/talkPick/domain/topic/domain/member/MemberTopicResult.java
@@ -21,7 +21,7 @@ public class MemberTopicResult {
     @Column(name = "member_topic_history_id",
             nullable = false,
             columnDefinition = "BIGINT COMMENT 'MemberTopicHistory ID'")
-    private Long member_topic_history_id;
+    private Long memberTopicHistoryId;
 
     @Column(
             name = "member_id",
@@ -30,5 +30,17 @@ public class MemberTopicResult {
     )
     private Long memberId;
 
+    /**
+     * 코멘트 업데이트
+     */
+    public void updateComment(String comment) {
+        this.comment = comment;
+    }
 
+    /**
+     * member_topic_history_id getter
+     */
+    public Long getMemberTopicHistoryId() {
+        return memberTopicHistoryId;
+    }
 }

--- a/src/main/java/talkPick/domain/topic/domain/member/MemberTopicResult.java
+++ b/src/main/java/talkPick/domain/topic/domain/member/MemberTopicResult.java
@@ -3,7 +3,6 @@ package talkPick.domain.topic.domain.member;
 
 import jakarta.persistence.*;
 import lombok.*;
-import talkPick.domain.member.domain.Member;
 
 @Getter
 @Setter
@@ -19,8 +18,10 @@ public class MemberTopicResult {
     @Column(length = 100)
     String comment;
 
-    @OneToOne(mappedBy = "memberTopicResult", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = true)
-    private MemberTopicHistory memberTopicHistory;
+    @Column(name = "member_topic_history_id",
+            nullable = false,
+            columnDefinition = "BIGINT COMMENT 'MemberTopicHistory ID'")
+    private Long member_topic_history_id;
 
     @Column(
             name = "member_id",

--- a/src/main/java/talkPick/domain/topic/domain/member/MemberTopicResult.java
+++ b/src/main/java/talkPick/domain/topic/domain/member/MemberTopicResult.java
@@ -22,8 +22,12 @@ public class MemberTopicResult {
     @OneToOne(mappedBy = "memberTopicResult", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = true)
     private MemberTopicHistory memberTopicHistory;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Member member;
+    @Column(
+            name = "member_id",
+            nullable = false,
+            columnDefinition = "BIGINT COMMENT '회원 PK (Foreign Key)'"
+    )
+    private Long memberId;
 
 
 }

--- a/src/main/java/talkPick/global/security/jwt/util/JwtProvider.java
+++ b/src/main/java/talkPick/global/security/jwt/util/JwtProvider.java
@@ -9,7 +9,6 @@ import talkPick.global.exception.ErrorCode;
 import talkPick.global.exception.handler.JwtExceptionHandler;
 import talkPick.global.exception.handler.SecurityExceptionHandler;
 import talkPick.global.security.jwt.dto.JwtResDTO;
-import java.security.Key;
 import java.util.List;
 
 import static talkPick.global.exception.ErrorCode.ROLE_NOT_FOUND;
@@ -19,8 +18,6 @@ import static talkPick.global.exception.ErrorCode.ROLE_NOT_FOUND;
 public class JwtProvider {
     private final JwtGenerator jwtGenerator;
     private final RefreshTokenGenerator refreshTokenGenerator;
-    private Key key;
-
 
     public JwtResDTO.Login createJwt(final Long memberId, final String role) {
         return JwtResDTO.Login.of(
@@ -53,7 +50,7 @@ public class JwtProvider {
      */
     public boolean validateToken(String token) {
         try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            Jwts.parserBuilder().setSigningKey(jwtGenerator.getSigningKey()).build().parseClaimsJws(token);
             return true;
         } catch (ExpiredJwtException e) {
             throw new JwtExceptionHandler(ErrorCode.EXPIRED_JWT_TOKEN);
@@ -85,7 +82,7 @@ public class JwtProvider {
         // 3. JWT에서 사용자 ID 추출
         try {
             // 추출
-            Claims claims = Jwts.parserBuilder().setSigningKey(key).build()
+            Claims claims = Jwts.parserBuilder().setSigningKey(jwtGenerator.getSigningKey()).build()
                     .parseClaimsJws(token).getBody();
             return Long.valueOf(claims.getSubject());
         } catch (Exception e) {

--- a/src/main/java/talkPick/global/security/model/WhiteList.java
+++ b/src/main/java/talkPick/global/security/model/WhiteList.java
@@ -16,6 +16,7 @@ public final class WhiteList {
             "/api/v1/members/delete",
             "/api/v1/members/liked-topics",
             "/api/v1/members/topic-results",
+            "api/v1/members/token/refresh",
             "/swagger-ui/**",
             "/swagger-ui.html/**",
             "/swagger-resources/**",


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **Branch**
- feature/#180

👷 **Work Done**
- 토픽 캘린더 조회 결과 API 기획에 맞게 수정
- 토픽 캘린더 조회 결과 코멘트 수정 API 추가

## ✅ Changes
### 1. 토픽 캘린더 결과 조회 기능 개발
- MemberResDto에 토픽 캘린더 결과 조회용 DTO(MemberTopicResultResDto, TopicResultCommentChangeRequest) 추가
- MemberTopicResultQuerydslRepository에 QueryDSL 기반 토픽 결과 조회 메서드 구현
- 특정 일자 기준, 커서 기반 페이징 조회 가능하도록 findMemberTopicResults 메서드 작성
- MemberQueryService에서 JWT 토큰으로 회원 ID 추출 후, 해당 회원의 특정 일자 토픽 결과를 페이징 조회하는 API 로직 구현
- MemberQueryController에 토픽 결과 조회 REST API 엔드포인트 추가 및 응답 구조 처리

### 2. 토픽 캘린더 결과 조회 토픽 코멘트 수정 API 개발
- 코멘트 수정 요청 DTO(TopicResultCommentChangeRequest) 추가
- 코멘트 수정 API를 통해 회원 토픽 히스토리의 코멘트를 변경할 수 있도록 서비스 및 컨트롤러에 기능 추가 (별도 구현 시점에 맞게 적용 가능)

## 🚨 Notes

## 📟 Related Issues
- Resolved: #180 
