### PR TITLE
[Feature] 문의하기 API

### DIFF
--- a/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryCommandApi.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryCommandApi.java
@@ -1,4 +1,18 @@
 package talkPick.domain.inquiry.adapter.in;
 
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import talkPick.domain.inquiry.adapter.in.dto.InquiryReqDto;
+
+@RequestMapping("/api/v1/inquiry")
 public interface InquiryCommandApi {
+    @PostMapping
+    @Operation(summary = "문의하기 API", description = "문의 양식에 맞게 정보(문의 유형, 이메일, 내용, 제목)를 입력 하여 문의하는 API입니다.")
+    void inquirySend(
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @Valid @RequestBody InquiryReqDto.inquiryDataRequest request);
 }

--- a/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryCommandApi.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryCommandApi.java
@@ -1,0 +1,4 @@
+package talkPick.domain.inquiry.adapter.in;
+
+public interface InquiryCommandApi {
+}

--- a/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryCommandApi.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryCommandApi.java
@@ -1,6 +1,7 @@
 package talkPick.domain.inquiry.adapter.in;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import talkPick.domain.inquiry.adapter.in.dto.InquiryReqDto;
 
 @RequestMapping("/api/v1/inquiry")
+@Tag(name = "문의 API", description = "문의 관련 API입니다.")
 public interface InquiryCommandApi {
     @PostMapping
     @Operation(summary = "문의하기 API", description = "문의 양식에 맞게 정보(문의 유형, 이메일, 내용, 제목)를 입력 하여 문의하는 API입니다.")

--- a/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryCommandController.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryCommandController.java
@@ -1,4 +1,23 @@
 package talkPick.domain.inquiry.adapter.in;
 
-public class InquiryCommandController {
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import talkPick.domain.inquiry.adapter.in.dto.InquiryReqDto;
+import talkPick.domain.inquiry.port.in.InquiryCommandUseCase;
+
+@RestController
+@RequiredArgsConstructor
+public class InquiryCommandController implements InquiryCommandApi{
+
+    private final InquiryCommandUseCase inquiryCommandUseCase;
+
+    @Override
+    public void inquirySend(
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @Valid @RequestBody InquiryReqDto.inquiryDataRequest request) {
+        inquiryCommandUseCase.inquirySend(authorization, request);
+    }
 }

--- a/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryCommandController.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryCommandController.java
@@ -1,0 +1,4 @@
+package talkPick.domain.inquiry.adapter.in;
+
+public class InquiryCommandController {
+}

--- a/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryQueryApi.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryQueryApi.java
@@ -15,7 +15,7 @@ import talkPick.global.response.CursorPageResponse;
 import java.time.LocalDateTime;
 
 @RequestMapping("/api/v1/inquiry")
-@Tag(name = "문의 조회 API", description = "회원이 등록한 문의 목록 조회 API")
+@Tag(name = "문의 API", description = "문의 관련 API입니다.")
 public interface InquiryQueryApi {
     @GetMapping
     @Operation(summary = "내 문의 목록 조회 API", description = "회원이 등록한 문의들을 커서 페이징으로 조회합니다.")

--- a/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryQueryApi.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryQueryApi.java
@@ -1,0 +1,4 @@
+package talkPick.domain.inquiry.adapter.in;
+
+public interface InquiryQueryApi {
+}

--- a/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryQueryApi.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryQueryApi.java
@@ -1,4 +1,27 @@
 package talkPick.domain.inquiry.adapter.in;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import talkPick.domain.inquiry.adapter.out.dto.InquiryResDto;
+import talkPick.global.response.CursorPageResponse;
+
+import java.time.LocalDateTime;
+
+@RequestMapping("/api/v1/inquiry")
+@Tag(name = "문의 조회 API", description = "회원이 등록한 문의 목록 조회 API")
 public interface InquiryQueryApi {
+    @GetMapping
+    @Operation(summary = "내 문의 목록 조회 API", description = "회원이 등록한 문의들을 커서 페이징으로 조회합니다.")
+    CursorPageResponse<InquiryResDto.InquiryListItemResDto> getMyInquiries(
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @RequestParam(value = "cursor", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursor,
+            @RequestParam(value = "size", defaultValue = "6") @Parameter(description = "페이지 크기 (1 이상)", schema = @Schema(minimum = "1")) int size
+    );
 }

--- a/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryQueryController.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryQueryController.java
@@ -1,4 +1,27 @@
 package talkPick.domain.inquiry.adapter.in;
 
-public class InquiryQueryController {
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import talkPick.domain.inquiry.adapter.out.dto.InquiryResDto;
+import talkPick.domain.inquiry.port.in.InquiryQueryUseCase;
+import talkPick.global.response.CursorPageResponse;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequiredArgsConstructor
+public class InquiryQueryController implements InquiryQueryApi {
+    private final InquiryQueryUseCase inquiryQueryUseCase;
+
+    @Override
+    public CursorPageResponse<InquiryResDto.InquiryListItemResDto> getMyInquiries(
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @RequestParam(value = "cursor", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime cursor,
+            @RequestParam(value = "size", defaultValue = "6") int size
+    ) {
+        return inquiryQueryUseCase.getMyInquiries(authorization, cursor, size);
+    }
 }

--- a/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryQueryController.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/in/InquiryQueryController.java
@@ -1,0 +1,4 @@
+package talkPick.domain.inquiry.adapter.in;
+
+public class InquiryQueryController {
+}

--- a/src/main/java/talkPick/domain/inquiry/adapter/in/dto/InquiryReqDto.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/in/dto/InquiryReqDto.java
@@ -1,0 +1,34 @@
+package talkPick.domain.inquiry.adapter.in.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import talkPick.domain.inquiry.domain.type.InquiryType;
+
+public class InquiryReqDto {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class inquiryDataRequest {
+        @NotNull(message = "문의 종류는 필수입니다.")
+        private InquiryType type;
+
+        @NotBlank(message = "이메일은 필수 입력 값입니다.")
+        @Email(message = "유효한 이메일 형식이어야 합니다.")
+        private String email;
+
+        @NotBlank(message = "문의 내용은 필수 입력 값입니다.")
+        @Size(max = 10000, message = "문의 내용은 10000자 이하여야 합니다.")
+        private String content;
+
+        @NotBlank(message = "문의 제목은 필수 입력 값입니다.")
+        @Size(max = 200, message = "문의 제목은 200자 이하여야 합니다.")
+        private String title;
+    }
+}

--- a/src/main/java/talkPick/domain/inquiry/adapter/out/InquiryCommandRepositoryAdapter.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/out/InquiryCommandRepositoryAdapter.java
@@ -1,0 +1,20 @@
+package talkPick.domain.inquiry.adapter.out;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import talkPick.domain.inquiry.adapter.out.repository.InquiryJpaRepository;
+import talkPick.domain.inquiry.domain.Inquiry;
+import talkPick.domain.inquiry.port.out.InquiryCommandRepositoryPort;
+
+@Component
+@RequiredArgsConstructor
+public class InquiryCommandRepositoryAdapter implements InquiryCommandRepositoryPort {
+    private final InquiryJpaRepository repository;
+
+    @Override
+    public Inquiry save(Inquiry inquiry) {
+        return repository.save(inquiry);
+    }
+}
+
+

--- a/src/main/java/talkPick/domain/inquiry/adapter/out/InquiryQueryRepositoryAdapter.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/out/InquiryQueryRepositoryAdapter.java
@@ -1,0 +1,24 @@
+package talkPick.domain.inquiry.adapter.out;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import talkPick.domain.inquiry.adapter.out.dto.InquiryResDto;
+import talkPick.domain.inquiry.adapter.out.repository.InquiryQuerydslRepository;
+import talkPick.domain.inquiry.port.out.InquiryQueryRepositoryPort;
+import talkPick.domain.member.domain.Member;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class InquiryQueryRepositoryAdapter implements InquiryQueryRepositoryPort {
+    private final InquiryQuerydslRepository repository;
+
+    @Override
+    public List<InquiryResDto.InquiryListItemResDto> findMyInquiries(Member member, LocalDateTime cursor, int size) {
+        return repository.findMyInquiries(member, cursor, size);
+    }
+}
+
+

--- a/src/main/java/talkPick/domain/inquiry/adapter/out/dto/InquiryResDto.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/out/dto/InquiryResDto.java
@@ -4,6 +4,20 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import talkPick.domain.inquiry.domain.type.InquiryType;
+
+import java.time.LocalDateTime;
 
 public class InquiryResDto {
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class InquiryListItemResDto {
+		private Long id;
+		private String title;
+		private InquiryType type;
+		private boolean answered;
+		private LocalDateTime createdDate;
+	}
 }

--- a/src/main/java/talkPick/domain/inquiry/adapter/out/dto/InquiryResDto.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/out/dto/InquiryResDto.java
@@ -1,0 +1,9 @@
+package talkPick.domain.inquiry.adapter.out.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class InquiryResDto {
+}

--- a/src/main/java/talkPick/domain/inquiry/adapter/out/repository/InquiryJpaRepository.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/out/repository/InquiryJpaRepository.java
@@ -1,0 +1,7 @@
+package talkPick.domain.inquiry.adapter.out.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import talkPick.domain.inquiry.domain.Inquiry;
+
+public interface InquiryJpaRepository extends JpaRepository<Inquiry, Long> {
+}

--- a/src/main/java/talkPick/domain/inquiry/adapter/out/repository/InquiryQuerydslRepository.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/out/repository/InquiryQuerydslRepository.java
@@ -1,0 +1,52 @@
+package talkPick.domain.inquiry.adapter.out.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+import talkPick.domain.inquiry.adapter.out.dto.InquiryResDto;
+import talkPick.domain.inquiry.domain.Inquiry;
+import talkPick.domain.inquiry.domain.QInquiry;
+import talkPick.domain.member.domain.Member;
+import talkPick.domain.inquiry.port.out.InquiryQueryRepositoryPort;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public class InquiryQuerydslRepository implements InquiryQueryRepositoryPort {
+    private final JPAQueryFactory queryFactory;
+
+    public InquiryQuerydslRepository(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<InquiryResDto.InquiryListItemResDto> findMyInquiries(Member member, LocalDateTime cursor, int size) {
+        QInquiry iq = QInquiry.inquiry;
+
+        BooleanBuilder builder = new BooleanBuilder()
+                .and(iq.memberId.eq(member.getId()));
+
+        if (cursor != null) {
+            builder.and(iq.createdDate.lt(cursor));
+        }
+
+        return queryFactory
+                .select(Projections.constructor(InquiryResDto.InquiryListItemResDto.class,
+                        iq.id,
+                        iq.title,
+                        iq.type,
+                        iq.isAnswered,
+                        iq.createdDate
+                ))
+                .from(iq)
+                .where(builder)
+                .orderBy(iq.createdDate.desc())
+                .limit(size + 1)
+                .fetch();
+    }
+}
+
+

--- a/src/main/java/talkPick/domain/inquiry/adapter/out/repository/InquiryQuerydslRepository.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/out/repository/InquiryQuerydslRepository.java
@@ -15,14 +15,13 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
-public class InquiryQuerydslRepository implements InquiryQueryRepositoryPort {
+public class InquiryQuerydslRepository {
     private final JPAQueryFactory queryFactory;
 
     public InquiryQuerydslRepository(EntityManager em) {
         this.queryFactory = new JPAQueryFactory(em);
     }
 
-    @Override
     public List<InquiryResDto.InquiryListItemResDto> findMyInquiries(Member member, LocalDateTime cursor, int size) {
         QInquiry iq = QInquiry.inquiry;
 

--- a/src/main/java/talkPick/domain/inquiry/application/InquiryCommandService.java
+++ b/src/main/java/talkPick/domain/inquiry/application/InquiryCommandService.java
@@ -5,7 +5,7 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import talkPick.domain.inquiry.adapter.in.dto.InquiryReqDto;
-import talkPick.domain.inquiry.adapter.out.repository.InquiryJpaRepository;
+import talkPick.domain.inquiry.port.out.InquiryCommandRepositoryPort;
 import talkPick.domain.inquiry.domain.Inquiry;
 import talkPick.domain.inquiry.port.in.InquiryCommandUseCase;
 import talkPick.domain.inquiry.converter.InquiryConverter;
@@ -16,7 +16,7 @@ import talkPick.global.security.jwt.util.JwtProvider;
 @RequiredArgsConstructor
 public class InquiryCommandService implements InquiryCommandUseCase {
 
-    private final InquiryJpaRepository inquiryJpaRepository;
+    private final InquiryCommandRepositoryPort inquiryCommandRepositoryPort;
     private final MemberJpaRepository memberJpaRepository;
     private final JwtProvider jwtProvider;
 
@@ -27,7 +27,7 @@ public class InquiryCommandService implements InquiryCommandUseCase {
 
         Inquiry inquiry = InquiryConverter.toInquiry(memberId, request);
 
-        inquiryJpaRepository.save(inquiry);
+        inquiryCommandRepositoryPort.save(inquiry);
 
     }
 

--- a/src/main/java/talkPick/domain/inquiry/application/InquiryCommandService.java
+++ b/src/main/java/talkPick/domain/inquiry/application/InquiryCommandService.java
@@ -1,7 +1,6 @@
 package talkPick.domain.inquiry.application;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import talkPick.domain.inquiry.adapter.in.dto.InquiryReqDto;
@@ -9,7 +8,6 @@ import talkPick.domain.inquiry.port.out.InquiryCommandRepositoryPort;
 import talkPick.domain.inquiry.domain.Inquiry;
 import talkPick.domain.inquiry.port.in.InquiryCommandUseCase;
 import talkPick.domain.inquiry.converter.InquiryConverter;
-import talkPick.domain.member.adapter.out.repository.MemberJpaRepository;
 import talkPick.global.security.jwt.util.JwtProvider;
 
 @Service
@@ -17,7 +15,6 @@ import talkPick.global.security.jwt.util.JwtProvider;
 public class InquiryCommandService implements InquiryCommandUseCase {
 
     private final InquiryCommandRepositoryPort inquiryCommandRepositoryPort;
-    private final MemberJpaRepository memberJpaRepository;
     private final JwtProvider jwtProvider;
 
     @Override

--- a/src/main/java/talkPick/domain/inquiry/application/InquiryCommandService.java
+++ b/src/main/java/talkPick/domain/inquiry/application/InquiryCommandService.java
@@ -1,0 +1,35 @@
+package talkPick.domain.inquiry.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import talkPick.domain.inquiry.adapter.in.dto.InquiryReqDto;
+import talkPick.domain.inquiry.adapter.out.repository.InquiryJpaRepository;
+import talkPick.domain.inquiry.domain.Inquiry;
+import talkPick.domain.inquiry.port.in.InquiryCommandUseCase;
+import talkPick.domain.inquiry.converter.InquiryConverter;
+import talkPick.domain.member.adapter.out.repository.MemberJpaRepository;
+import talkPick.global.security.jwt.util.JwtProvider;
+
+@Service
+@RequiredArgsConstructor
+public class InquiryCommandService implements InquiryCommandUseCase {
+
+    private final InquiryJpaRepository inquiryJpaRepository;
+    private final MemberJpaRepository memberJpaRepository;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    @Transactional
+    public void inquirySend(String authorization, InquiryReqDto.inquiryDataRequest request) {
+        Long memberId = jwtProvider.getMemberId(authorization);
+
+        Inquiry inquiry = InquiryConverter.toInquiry(memberId, request);
+
+        inquiryJpaRepository.save(inquiry);
+
+    }
+
+
+}

--- a/src/main/java/talkPick/domain/inquiry/application/InquiryQueryService.java
+++ b/src/main/java/talkPick/domain/inquiry/application/InquiryQueryService.java
@@ -1,7 +1,54 @@
 package talkPick.domain.inquiry.application;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import talkPick.domain.inquiry.adapter.out.dto.InquiryResDto;
 import talkPick.domain.inquiry.port.in.InquiryQueryUseCase;
+import talkPick.domain.inquiry.port.out.InquiryQueryRepositoryPort;
+import talkPick.domain.member.adapter.out.repository.MemberJpaRepository;
+import talkPick.domain.member.domain.Member;
+import talkPick.global.exception.ErrorCode;
+import talkPick.global.exception.handler.MemberExceptionHandler;
+import talkPick.global.response.CursorPageResponse;
+import talkPick.global.security.jwt.util.JwtProvider;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class InquiryQueryService implements InquiryQueryUseCase {
+    private final MemberJpaRepository memberJpaRepository;
+    private final InquiryQueryRepositoryPort inquiryQueryRepositoryPort;
+    private final JwtProvider jwtProvider;
 
+    @Override
+    public CursorPageResponse<InquiryResDto.InquiryListItemResDto> getMyInquiries(String authorization, LocalDateTime cursor, int size) {
+        Long memberId = jwtProvider.getMemberId(authorization);
+
+        Member findMember = memberJpaRepository.findById(memberId)
+                .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
+        // size + 1개 조회하여 다음 페이지 존재 여부 판단
+        List<InquiryResDto.InquiryListItemResDto> items = inquiryQueryRepositoryPort.findMyInquiries(findMember, cursor, size + 1);
+
+        // 다음 페이지 존재 시 마지막 데이터 제거
+        boolean hasNext = items.size() > size;
+        if (hasNext) items.remove(items.size() - 1);
+
+        // 다음 페이지 조회용 커서 생성
+        CursorPageResponse.Cursor nextCursor = null;
+        if (hasNext && !items.isEmpty()) {
+            InquiryResDto.InquiryListItemResDto last = items.get(items.size() - 1);
+            nextCursor = new CursorPageResponse.Cursor(last.getCreatedDate(), last.getId());
+        }
+
+        // 커서 기반 페이징 응답 반환
+        return CursorPageResponse.<InquiryResDto.InquiryListItemResDto>builder()
+                .items(items)
+                .hasNext(hasNext)
+                .nextCursor(nextCursor)
+                .build();
+    }
 }

--- a/src/main/java/talkPick/domain/inquiry/application/InquiryQueryService.java
+++ b/src/main/java/talkPick/domain/inquiry/application/InquiryQueryService.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import talkPick.domain.inquiry.adapter.out.dto.InquiryResDto;
 import talkPick.domain.inquiry.port.in.InquiryQueryUseCase;
 import talkPick.domain.inquiry.port.out.InquiryQueryRepositoryPort;
-import talkPick.domain.member.adapter.out.repository.MemberJpaRepository;
+import talkPick.domain.member.port.out.MemberQueryRepositoryPort;
 import talkPick.domain.member.domain.Member;
 import talkPick.global.exception.ErrorCode;
 import talkPick.global.exception.handler.MemberExceptionHandler;
@@ -20,7 +20,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class InquiryQueryService implements InquiryQueryUseCase {
-    private final MemberJpaRepository memberJpaRepository;
+    private final MemberQueryRepositoryPort memberQueryRepositoryPort;
     private final InquiryQueryRepositoryPort inquiryQueryRepositoryPort;
     private final JwtProvider jwtProvider;
 
@@ -28,8 +28,7 @@ public class InquiryQueryService implements InquiryQueryUseCase {
     public CursorPageResponse<InquiryResDto.InquiryListItemResDto> getMyInquiries(String authorization, LocalDateTime cursor, int size) {
         Long memberId = jwtProvider.getMemberId(authorization);
 
-        Member findMember = memberJpaRepository.findById(memberId)
-                .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
+        Member findMember = memberQueryRepositoryPort.findMemberById(memberId);
         // size + 1개 조회하여 다음 페이지 존재 여부 판단
         List<InquiryResDto.InquiryListItemResDto> items = inquiryQueryRepositoryPort.findMyInquiries(findMember, cursor, size + 1);
 

--- a/src/main/java/talkPick/domain/inquiry/application/InquiryQueryService.java
+++ b/src/main/java/talkPick/domain/inquiry/application/InquiryQueryService.java
@@ -1,0 +1,7 @@
+package talkPick.domain.inquiry.application;
+
+import talkPick.domain.inquiry.port.in.InquiryQueryUseCase;
+
+public class InquiryQueryService implements InquiryQueryUseCase {
+
+}

--- a/src/main/java/talkPick/domain/inquiry/converter/InquiryConverter.java
+++ b/src/main/java/talkPick/domain/inquiry/converter/InquiryConverter.java
@@ -1,0 +1,21 @@
+package talkPick.domain.inquiry.converter;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import talkPick.domain.inquiry.adapter.in.dto.InquiryReqDto;
+import talkPick.domain.inquiry.domain.Inquiry;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class InquiryConverter {
+
+    public static Inquiry toInquiry(Long memberId, InquiryReqDto.inquiryDataRequest request) {
+        return Inquiry.builder()
+                .memberId(memberId)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .email(request.getEmail())
+                .type(request.getType())
+                .isAnswered(false)
+                .build();
+    }
+}

--- a/src/main/java/talkPick/domain/inquiry/domain/Inquiry.java
+++ b/src/main/java/talkPick/domain/inquiry/domain/Inquiry.java
@@ -1,0 +1,43 @@
+package talkPick.domain.inquiry.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import talkPick.domain.inquiry.domain.type.InquiryType;
+import talkPick.global.model.BaseTime;
+
+@Entity
+@Table(name = "inquiry")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Inquiry extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "inquiry_id", nullable = false, columnDefinition = "BIGINT COMMENT '기본 키'")
+    private Long id;
+
+    @Column(
+            name = "member_id",
+            nullable = false,
+            columnDefinition = "BIGINT COMMENT '회원 PK (Foreign Key)'"
+    )
+    private Long memberId;
+
+    @Column(name = "title", nullable = false, length = 200, columnDefinition = "VARCHAR(200) COMMENT '문의 제목'")
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT COMMENT '문의 본문 내용'")
+    private String content;
+
+    @Column(name = "email", nullable = false, length = 100, columnDefinition = "VARCHAR(100) COMMENT '답변 받을 이메일'")
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20, columnDefinition = "VARCHAR(20) COMMENT '문의 상태'")
+    private InquiryType type;
+
+    @Column(name = "is_answered", nullable = false, columnDefinition = "TINYINT(1) COMMENT '답변 완료 여부'")
+    private boolean isAnswered;
+}

--- a/src/main/java/talkPick/domain/inquiry/domain/type/InquiryType.java
+++ b/src/main/java/talkPick/domain/inquiry/domain/type/InquiryType.java
@@ -1,0 +1,8 @@
+package talkPick.domain.inquiry.domain.type;
+
+public enum InquiryType {
+    BUG_REPORT,      // 버그 신고
+    FEEDBACK,        // 기타 피드백
+    GENERAL,         // 일반 문의
+    FEATURE_REQUEST  // 기능 추가 요청
+}

--- a/src/main/java/talkPick/domain/inquiry/port/in/InquiryCommandUseCase.java
+++ b/src/main/java/talkPick/domain/inquiry/port/in/InquiryCommandUseCase.java
@@ -1,0 +1,4 @@
+package talkPick.domain.inquiry.port.in;
+
+public interface InquiryCommandUseCase {
+}

--- a/src/main/java/talkPick/domain/inquiry/port/in/InquiryCommandUseCase.java
+++ b/src/main/java/talkPick/domain/inquiry/port/in/InquiryCommandUseCase.java
@@ -1,4 +1,7 @@
 package talkPick.domain.inquiry.port.in;
 
+import talkPick.domain.inquiry.adapter.in.dto.InquiryReqDto;
+
 public interface InquiryCommandUseCase {
+    void inquirySend(String authorization, InquiryReqDto.inquiryDataRequest request);
 }

--- a/src/main/java/talkPick/domain/inquiry/port/in/InquiryQueryUseCase.java
+++ b/src/main/java/talkPick/domain/inquiry/port/in/InquiryQueryUseCase.java
@@ -1,0 +1,4 @@
+package talkPick.domain.inquiry.port.in;
+
+public interface InquiryQueryUseCase {
+}

--- a/src/main/java/talkPick/domain/inquiry/port/in/InquiryQueryUseCase.java
+++ b/src/main/java/talkPick/domain/inquiry/port/in/InquiryQueryUseCase.java
@@ -1,4 +1,10 @@
 package talkPick.domain.inquiry.port.in;
 
+import talkPick.domain.inquiry.adapter.out.dto.InquiryResDto;
+import talkPick.global.response.CursorPageResponse;
+
+import java.time.LocalDateTime;
+
 public interface InquiryQueryUseCase {
+    CursorPageResponse<InquiryResDto.InquiryListItemResDto> getMyInquiries(String authorization, LocalDateTime cursor, int size);
 }

--- a/src/main/java/talkPick/domain/inquiry/port/out/InquiryCommandRepositoryPort.java
+++ b/src/main/java/talkPick/domain/inquiry/port/out/InquiryCommandRepositoryPort.java
@@ -1,0 +1,9 @@
+package talkPick.domain.inquiry.port.out;
+
+import talkPick.domain.inquiry.domain.Inquiry;
+
+public interface InquiryCommandRepositoryPort {
+    Inquiry save(Inquiry inquiry);
+}
+
+

--- a/src/main/java/talkPick/domain/inquiry/port/out/InquiryQueryRepositoryPort.java
+++ b/src/main/java/talkPick/domain/inquiry/port/out/InquiryQueryRepositoryPort.java
@@ -1,0 +1,13 @@
+package talkPick.domain.inquiry.port.out;
+
+import talkPick.domain.inquiry.adapter.out.dto.InquiryResDto;
+import talkPick.domain.member.domain.Member;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface InquiryQueryRepositoryPort {
+    List<InquiryResDto.InquiryListItemResDto> findMyInquiries(Member member, LocalDateTime cursor, int size);
+}
+
+

--- a/src/main/java/talkPick/domain/member/adapter/out/MemberCommandRepositoryAdapter.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/MemberCommandRepositoryAdapter.java
@@ -1,0 +1,37 @@
+package talkPick.domain.member.adapter.out;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import talkPick.domain.member.adapter.out.repository.MemberJpaRepository;
+import talkPick.domain.member.domain.Member;
+import talkPick.domain.member.port.out.MemberCommandRepositoryPort;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class MemberCommandRepositoryAdapter implements MemberCommandRepositoryPort {
+    private final MemberJpaRepository repository;
+
+    @Override
+    public Member save(Member member) {
+        return repository.save(member);
+    }
+
+    @Override
+    public Optional<Member> findById(Long memberId) {
+        return repository.findById(memberId);
+    }
+
+    @Override
+    public Optional<Member> findByEmail(String email) {
+        return repository.findByEmail(email);
+    }
+
+    @Override
+    public Optional<Member> findByProviderId(String providerId) {
+        return repository.findByProviderId(providerId);
+    }
+}
+
+

--- a/src/main/java/talkPick/domain/member/adapter/out/MemberTermCommandRepositoryAdapter.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/MemberTermCommandRepositoryAdapter.java
@@ -1,0 +1,29 @@
+package talkPick.domain.member.adapter.out;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import talkPick.domain.member.adapter.out.repository.MemberTermJpaRepository;
+import talkPick.domain.member.domain.Member;
+import talkPick.domain.term.domain.Term;
+import talkPick.domain.member.domain.MemberTerm;
+import talkPick.domain.member.port.out.MemberTermCommandRepositoryPort;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class MemberTermCommandRepositoryAdapter implements MemberTermCommandRepositoryPort {
+    private final MemberTermJpaRepository repository;
+
+    @Override
+    public Optional<MemberTerm> findByMemberIdAndTermId(Long memberId, Long termId) {
+        return repository.findByMemberIdAndTermId(memberId, termId);
+    }
+
+    @Override
+    public MemberTerm save(MemberTerm memberTerm) {
+        return repository.save(memberTerm);
+    }
+}
+
+

--- a/src/main/java/talkPick/domain/member/adapter/out/MemberTermCommandRepositoryAdapter.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/MemberTermCommandRepositoryAdapter.java
@@ -3,9 +3,7 @@ package talkPick.domain.member.adapter.out;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import talkPick.domain.member.adapter.out.repository.MemberTermJpaRepository;
-import talkPick.domain.member.domain.Member;
-import talkPick.domain.term.domain.Term;
-import talkPick.domain.member.domain.MemberTerm;
+import talkPick.domain.member.domain.mapping.MemberTerm;
 import talkPick.domain.member.port.out.MemberTermCommandRepositoryPort;
 
 import java.util.Optional;

--- a/src/main/java/talkPick/domain/member/adapter/out/TermQueryRepositoryAdapter.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/TermQueryRepositoryAdapter.java
@@ -1,0 +1,28 @@
+package talkPick.domain.member.adapter.out;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import talkPick.domain.term.adapter.out.repository.TermJpaRepository;
+import talkPick.domain.term.domain.Term;
+import talkPick.domain.term.port.out.TermQueryRepositoryPort;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class TermQueryRepositoryAdapter implements TermQueryRepositoryPort {
+    private final TermJpaRepository repository;
+
+    @Override
+    public Optional<Term> findById(Long termId) {
+        return repository.findById(termId);
+    }
+
+    @Override
+    public List<Term> findByIsRequiredTrue() {
+        return repository.findByIsRequiredTrue();
+    }
+}
+
+

--- a/src/main/java/talkPick/domain/member/adapter/out/dto/MemberResDto.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/dto/MemberResDto.java
@@ -11,17 +11,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public class MemberResDto {
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class LoginTokenResponse {
-        private String accessToken;
-        private String refreshToken;
-        private LocalDateTime accessTokenExpireAt;
-        private TalkPickStatus talkPickStatus;
-    }
-
 
     @Getter
     @Builder
@@ -31,15 +20,6 @@ public class MemberResDto {
         private Long memberId;
         private String message;
         private TalkPickStatus talkPickStatus;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class RefreshAccessTokenResponse {
-        private String accessToken;
-        private LocalDateTime accessTokenExpireAt;
     }
 
     @Getter
@@ -65,6 +45,7 @@ public class MemberResDto {
     }
 
     @Getter
+    @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     public static class MemberTopicResultResDto {
@@ -75,10 +56,10 @@ public class MemberResDto {
     }
 
     @Getter
-    @Setter
-    @NoArgsConstructor
+    @Builder
     @AllArgsConstructor
-    public class MemberLikedTopicResDto {
+    @NoArgsConstructor
+    public static class MemberLikedTopicResDto {
         private Long id; // 좋아요 누른 토픽 id (TopicLikeHistory 테이블)
         private String title;  //토픽 주제 (Topic 테이블)
         private long averageTalkTime; //평균 대화 시간 (Topic 테이블)

--- a/src/main/java/talkPick/domain/member/application/MemberCommandService.java
+++ b/src/main/java/talkPick/domain/member/application/MemberCommandService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import talkPick.domain.member.adapter.out.repository.MemberJpaRepository;
+import talkPick.domain.member.port.out.MemberCommandRepositoryPort;
 import talkPick.domain.member.adapter.out.repository.MemberTermJpaRepository;
 import talkPick.domain.member.adapter.out.repository.MemberTopicResultJpaRepository;
 import talkPick.domain.member.converter.MemberConverter;
@@ -34,7 +34,7 @@ import java.util.List;
 public class MemberCommandService implements MemberCommandUseCase {
     private static final String DEFAULT_PROFILE_IMG_URL = "https://example.com/images/default-profile.png";
 
-    private final MemberJpaRepository memberJpaRepository;
+    private final MemberCommandRepositoryPort memberCommandRepositoryPort;
     private final TermJpaRepository termJpaRepository;
     private final MemberTermJpaRepository memberTermJpaRepository;
     private final RefreshTokenRepository refreshTokenRepository;
@@ -51,7 +51,7 @@ public class MemberCommandService implements MemberCommandUseCase {
         Long memberId = jwtProvider.getMemberId(authorization);
 
         // 회원 조회
-        Member findMember = memberJpaRepository.findById(memberId)
+        Member findMember = memberCommandRepositoryPort.findById(memberId)
                 .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
         System.out.println("회원 이름 :" + request.getNickname());
         // 요청된 필드별 수정 처리
@@ -60,7 +60,7 @@ public class MemberCommandService implements MemberCommandUseCase {
         if (request.getBirth() != null) findMember.updateBirth(request.getBirth());
         if (request.getMbti() != null) findMember.updateMbti(request.getMbti());
 
-        memberJpaRepository.save(findMember);
+        memberCommandRepositoryPort.save(findMember);
 
         return MemberConverter.toProfileUpdateResponse(findMember);
     }
@@ -72,7 +72,7 @@ public class MemberCommandService implements MemberCommandUseCase {
     public Member findOrCreateEmailMember(MemberReqDto.MemberEmailRequest emailReqDto) {
         validatePassword(emailReqDto.getPassword());
 
-        if (memberJpaRepository.findByEmail(emailReqDto.getEmail()).isPresent()) {
+        if (memberCommandRepositoryPort.findByEmail(emailReqDto.getEmail()).isPresent()) {
             throw new MemberExceptionHandler(ErrorCode.MEMBER_EMAIL_ALREADY_EXISTS);
         }
 
@@ -80,7 +80,7 @@ public class MemberCommandService implements MemberCommandUseCase {
 
         // 비밀번호 암호화
         newMember.updatePassword(passwordEncoder.encode(emailReqDto.getPassword()));
-        return memberJpaRepository.save(newMember);
+        return memberCommandRepositoryPort.save(newMember);
     }
 
     /**
@@ -90,7 +90,7 @@ public class MemberCommandService implements MemberCommandUseCase {
     public Member loginEmailMember(MemberReqDto.MemberEmailRequest emailReqDto) {
         validatePassword(emailReqDto.getPassword());
 
-        Member member = memberJpaRepository.findByEmail(emailReqDto.getEmail())
+        Member member = memberCommandRepositoryPort.findByEmail(emailReqDto.getEmail())
                 .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
 
         // 비밀번호 복호화 및 검증
@@ -109,10 +109,10 @@ public class MemberCommandService implements MemberCommandUseCase {
      */
     @Override
     public Member findOrCreateKakaoMember(MemberDataDto.KakaoMemberData kakaoMemberData) {
-        Member findOrNewMember = memberJpaRepository.findByProviderId(kakaoMemberData.getSub())
+        Member findOrNewMember = memberCommandRepositoryPort.findByProviderId(kakaoMemberData.getSub())
                 .orElseGet(() -> MemberConverter.toKakaoMember(kakaoMemberData));
 
-        return memberJpaRepository.save(findOrNewMember);
+        return memberCommandRepositoryPort.save(findOrNewMember);
     }
 
     /**
@@ -122,7 +122,7 @@ public class MemberCommandService implements MemberCommandUseCase {
     public MemberResDto.MemberSignupResponse memberSignup(String authorization, MemberReqDto.MemberSignupRequest request) {
         Long memberId = jwtProvider.getMemberId(authorization);
 
-        Member findMember = memberJpaRepository.findById(memberId)
+        Member findMember = memberCommandRepositoryPort.findById(memberId)
                 .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
 
         if (!validateAdditionalInfo(request)) {
@@ -144,7 +144,7 @@ public class MemberCommandService implements MemberCommandUseCase {
 
         // 회원 ACTIVE 상태 변경
         findMember.updateStatus(TalkPickStatus.ACTIVE);
-        memberJpaRepository.save(findMember);
+        memberCommandRepositoryPort.save(findMember);
 
         // 이메일 회원은 임시 토큰 삭제 처리
         if (findMember.getLoginType() == LoginType.EMAIL) {
@@ -167,7 +167,7 @@ public class MemberCommandService implements MemberCommandUseCase {
     public MemberResDto.TermAgreementResponse termAgreement(String authorization, MemberReqDto.TermAgreementRequest request) {
         Long memberId = jwtProvider.getMemberId(authorization);
 
-        Member findMember = memberJpaRepository.findById(memberId)
+        Member findMember = memberCommandRepositoryPort.findById(memberId)
                 .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
 
         List<Long> agreeTermIdList = request.getAgreeTermIdList();
@@ -201,7 +201,7 @@ public class MemberCommandService implements MemberCommandUseCase {
 
         // 회원 상태 변경 및 저장
         findMember.updateStatus(TalkPickStatus.AGREE);
-        memberJpaRepository.save(findMember);
+        memberCommandRepositoryPort.save(findMember);
 
         return MemberConverter.toTermAgreementResponse(findMember);
     }

--- a/src/main/java/talkPick/domain/member/application/MemberCommandService.java
+++ b/src/main/java/talkPick/domain/member/application/MemberCommandService.java
@@ -5,7 +5,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import talkPick.domain.member.port.out.MemberCommandRepositoryPort;
-import talkPick.domain.member.adapter.out.repository.MemberTermJpaRepository;
+import talkPick.domain.member.port.out.MemberTermCommandRepositoryPort;
 import talkPick.domain.member.adapter.out.repository.MemberTopicResultJpaRepository;
 import talkPick.domain.member.converter.MemberConverter;
 import talkPick.domain.member.domain.Member;
@@ -16,7 +16,8 @@ import talkPick.domain.member.adapter.in.dto.MemberReqDto;
 import talkPick.domain.member.adapter.out.dto.MemberResDto;
 import talkPick.domain.member.port.in.MemberCommandUseCase;
 import talkPick.domain.member.port.out.MemberLoginHistoryCommandRepositoryPort;
-import talkPick.domain.term.adapter.out.repository.TermJpaRepository;
+import talkPick.domain.member.port.out.MemberQueryRepositoryPort;
+import talkPick.domain.term.port.out.TermQueryRepositoryPort;
 import talkPick.domain.term.domain.Term;
 import talkPick.domain.topic.domain.member.MemberTopicResult;
 import talkPick.global.security.jwt.repository.RefreshTokenRepository;
@@ -35,10 +36,11 @@ public class MemberCommandService implements MemberCommandUseCase {
     private static final String DEFAULT_PROFILE_IMG_URL = "https://example.com/images/default-profile.png";
 
     private final MemberCommandRepositoryPort memberCommandRepositoryPort;
-    private final TermJpaRepository termJpaRepository;
-    private final MemberTermJpaRepository memberTermJpaRepository;
+    private final TermQueryRepositoryPort termQueryRepositoryPort;
+    private final MemberTermCommandRepositoryPort memberTermJpaRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final MemberLoginHistoryCommandRepositoryPort memberLoginHistoryRepository;
+    private final MemberQueryRepositoryPort memberQueryRepositoryPort;
     private final JwtProvider jwtProvider;
     private final PasswordEncoder passwordEncoder;
     private final MemberTopicResultJpaRepository memberTopicResultJpaRepository;
@@ -179,7 +181,7 @@ public class MemberCommandService implements MemberCommandUseCase {
 
         // 동의한 약관 저장 및 업데이트
         for (Long termId : agreeTermIdList) {
-            Term term = termJpaRepository.findById(termId)
+            Term term = termQueryRepositoryPort.findById(termId)
                     .orElseThrow(() -> new TermExceptionHandler(ErrorCode.TERM_NOT_FOUND));
             memberTermJpaRepository.findByMemberIdAndTermId(findMember.getId(), term.getId())
                     .ifPresentOrElse(
@@ -190,7 +192,7 @@ public class MemberCommandService implements MemberCommandUseCase {
 
         // 미동의한 약관 저장 및 업데이트
         for (Long termId : disagreeTermIdList) {
-            Term term = termJpaRepository.findById(termId)
+            Term term = termQueryRepositoryPort.findById(termId)
                     .orElseThrow(() -> new TermExceptionHandler(ErrorCode.TERM_NOT_FOUND));
             memberTermJpaRepository.findByMemberIdAndTermId(findMember.getId(), term.getId())
                     .ifPresentOrElse(
@@ -211,8 +213,7 @@ public class MemberCommandService implements MemberCommandUseCase {
     public void logout(String authorization) {
         Long memberId = jwtProvider.getMemberId(authorization);
 
-        Member findMember = memberJpaRepository.findById(memberId)
-                .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
+        Member findMember = memberQueryRepositoryPort.findMemberById(memberId);
 
         refreshTokenRepository.deleteByMemberId(findMember.getId());
         memberLoginHistoryRepository.deleteByMemberId(findMember.getId());
@@ -223,11 +224,10 @@ public class MemberCommandService implements MemberCommandUseCase {
     public void delete(String authorization) {
         Long memberId = jwtProvider.getMemberId(authorization);
 
-        Member findMember = memberJpaRepository.findById(memberId)
-                .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
+        Member findMember = memberQueryRepositoryPort.findMemberById(memberId);
 
         findMember.updateStatus(TalkPickStatus.DIS_ACTIVE);
-        memberJpaRepository.save(findMember);
+        memberCommandRepositoryPort.save(findMember);
 
         refreshTokenRepository.deleteByMemberId(findMember.getId());
         memberLoginHistoryRepository.deleteByMemberId(findMember.getId());
@@ -239,8 +239,7 @@ public class MemberCommandService implements MemberCommandUseCase {
         Long memberId = jwtProvider.getMemberId(authorization);
 
         // 회원 조회
-        Member findMember = memberJpaRepository.findById(memberId)
-                .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
+        Member findMember = memberQueryRepositoryPort.findMemberById(memberId);
 
         // MemberTopicResult 조회 (member_topic_history_id로 조회)
         MemberTopicResult findMemberTopicResult = memberTopicResultJpaRepository.findByMemberTopicHistoryId(request.getMemberTopicHistoryId())
@@ -268,7 +267,7 @@ public class MemberCommandService implements MemberCommandUseCase {
     private boolean validateRequiredTerms(List<Long> agreeTermIdList) {
         if (agreeTermIdList == null) return false;
 
-        List<Term> requiredTerms = termJpaRepository.findByIsRequiredTrue();
+        List<Term> requiredTerms = termQueryRepositoryPort.findByIsRequiredTrue();
 
         for (Term term : requiredTerms) {
             if (!agreeTermIdList.contains(term.getId())) {

--- a/src/main/java/talkPick/domain/member/application/MemberQueryService.java
+++ b/src/main/java/talkPick/domain/member/application/MemberQueryService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import talkPick.domain.member.adapter.out.dto.MemberResDto;
 import talkPick.domain.member.converter.MemberConverter;
-import talkPick.domain.member.adapter.out.repository.MemberJpaRepository;
+import talkPick.domain.member.port.out.MemberQueryRepositoryPort;
 import talkPick.domain.member.domain.Member;
 import talkPick.domain.member.port.in.MemberQueryUseCase;
 import talkPick.domain.member.port.out.MemberLikedTopicsQueryRepositoryPort;
@@ -24,7 +24,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemberQueryService implements MemberQueryUseCase {
-    private final MemberJpaRepository memberJpaRepository;
+    private final MemberQueryRepositoryPort memberQueryRepositoryPort;
     private final MemberLikedTopicsQueryRepositoryPort memberLikedTopicsQueryRepositoryPort;
     private final MemberTopicResultQueryRepositoryPort memberTopicResultQueryRepositoryPort;
     private final JwtProvider jwtProvider;
@@ -36,8 +36,7 @@ public class MemberQueryService implements MemberQueryUseCase {
         Long memberId = jwtProvider.getMemberId(authorization);
 
         // 회원 존재 여부 검증 및 조회
-        Member findMember = memberJpaRepository.findById(memberId)
-                .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
+        Member findMember = memberQueryRepositoryPort.findMemberById(memberId);
 
         // 조회된 회원 정보를 DTO로 변환 후 반환
         return MemberConverter.toProfileResponse(findMember);
@@ -50,8 +49,7 @@ public class MemberQueryService implements MemberQueryUseCase {
     public CursorPageResponse<MemberResDto.MemberLikedTopicResDto> getMemberLikedTopics(String authorization, LocalDateTime cursor, int size) {
         Long memberId = jwtProvider.getMemberId(authorization);
 
-        Member findMember = memberJpaRepository.findById(memberId)
-                .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
+        Member findMember = memberQueryRepositoryPort.findMemberById(memberId);
 
         // size + 1개 조회하여 다음 페이지 존재 여부 판단
         List<MemberResDto.MemberLikedTopicResDto> memberLikedTopics = memberLikedTopicsQueryRepositoryPort.findMemberLikedTopics(findMember, cursor, size + 1);
@@ -82,8 +80,7 @@ public class MemberQueryService implements MemberQueryUseCase {
     public CursorPageResponse<MemberResDto.MemberTopicResultResDto> getMemberTopicResultsByCreatedDate(String authorization, LocalDate date, LocalDateTime cursor, int size) {
         Long memberId = jwtProvider.getMemberId(authorization);
 
-        Member findMember = memberJpaRepository.findById(memberId)
-                .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
+        Member findMember = memberQueryRepositoryPort.findMemberById(memberId);
 
         // size + 1개 조회하여 다음 페이지 존재 여부 판단
         List<MemberResDto.MemberTopicResultResDto> items = memberTopicResultQueryRepositoryPort.findMemberTopicResults(findMember, date, cursor, size + 1);

--- a/src/main/java/talkPick/domain/member/port/out/MemberCommandRepositoryPort.java
+++ b/src/main/java/talkPick/domain/member/port/out/MemberCommandRepositoryPort.java
@@ -1,0 +1,14 @@
+package talkPick.domain.member.port.out;
+
+import talkPick.domain.member.domain.Member;
+
+import java.util.Optional;
+
+public interface MemberCommandRepositoryPort {
+    Member save(Member member);
+    Optional<Member> findById(Long memberId);
+    Optional<Member> findByEmail(String email);
+    Optional<Member> findByProviderId(String providerId);
+}
+
+

--- a/src/main/java/talkPick/domain/member/port/out/MemberTermCommandRepositoryPort.java
+++ b/src/main/java/talkPick/domain/member/port/out/MemberTermCommandRepositoryPort.java
@@ -1,6 +1,6 @@
 package talkPick.domain.member.port.out;
 
-import talkPick.domain.member.domain.MemberTerm;
+import talkPick.domain.member.domain.mapping.MemberTerm;
 
 import java.util.Optional;
 

--- a/src/main/java/talkPick/domain/member/port/out/MemberTermCommandRepositoryPort.java
+++ b/src/main/java/talkPick/domain/member/port/out/MemberTermCommandRepositoryPort.java
@@ -1,0 +1,12 @@
+package talkPick.domain.member.port.out;
+
+import talkPick.domain.member.domain.MemberTerm;
+
+import java.util.Optional;
+
+public interface MemberTermCommandRepositoryPort {
+    Optional<MemberTerm> findByMemberIdAndTermId(Long memberId, Long termId);
+    MemberTerm save(MemberTerm memberTerm);
+}
+
+

--- a/src/main/java/talkPick/domain/term/port/out/TermQueryRepositoryPort.java
+++ b/src/main/java/talkPick/domain/term/port/out/TermQueryRepositoryPort.java
@@ -1,0 +1,13 @@
+package talkPick.domain.term.port.out;
+
+import talkPick.domain.term.domain.Term;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TermQueryRepositoryPort {
+    Optional<Term> findById(Long termId);
+    List<Term> findByIsRequiredTrue();
+}
+
+

--- a/src/main/java/talkPick/global/config/JacksonConfig.java
+++ b/src/main/java/talkPick/global/config/JacksonConfig.java
@@ -11,7 +11,7 @@ import java.time.format.DateTimeFormatter;
 
 @Configuration
 public class JacksonConfig {
-    private static final String DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
+    private static final String DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS";
     private static final LocalDateTimeSerializer LOCAL_DATETIME_SERIALIZER =
             new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(DATETIME_FORMAT));
 

--- a/src/main/java/talkPick/global/config/SpringDocOpenApiConfig.java
+++ b/src/main/java/talkPick/global/config/SpringDocOpenApiConfig.java
@@ -86,4 +86,13 @@ public class SpringDocOpenApiConfig {
                 .pathsToMatch("/api/v1/members/**")
                 .build();
     }
+
+    @Bean
+    public GroupedOpenApi inquiryOpenApi() {
+        return GroupedOpenApi.builder()
+                .group("문의 API")
+                .displayName("문의 API")
+                .pathsToMatch("/api/v1/inquiry/**")
+                .build();
+    }
 }

--- a/src/main/java/talkPick/global/exception/ErrorCode.java
+++ b/src/main/java/talkPick/global/exception/ErrorCode.java
@@ -83,7 +83,7 @@ public enum ErrorCode {
     // Kakao
     INVALID_ID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 ID Token 입니다."),
     ERROR_ON_VERIFYING(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 토큰 검증 도중 에러 발생"),
-
+    
     ;
 
     private final HttpStatus status;

--- a/src/main/java/talkPick/global/security/model/WhiteList.java
+++ b/src/main/java/talkPick/global/security/model/WhiteList.java
@@ -17,6 +17,7 @@ public final class WhiteList {
             "/api/v1/members/liked-topics",
             "/api/v1/members/topic-results",
             "api/v1/members/token/refresh",
+            "/api/v1/inquiry",
             "/swagger-ui/**",
             "/swagger-ui.html/**",
             "/swagger-resources/**",


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **Branch**
- feature/#183

👷 **Work Done**
- 문의 커서 페이지네이션 조회 구현
- 문의하기 구현

## ✅ Changes
### 1. InquiryCommandApi 및 Controller
- 문의하기 API 인터페이스 InquiryCommandApi 정의 및 스프링 REST 컨트롤러 InquiryCommandController 구현

### 2. InquiryCommandService 및 RepositoryAdapter
- 회원 인증 후 문의 데이터 저장 처리 로직 구현 (inquirySend)
- 문의 저장을 위한 JPA 리포지토리를 감싼 InquiryCommandRepositoryPort 인터페이스 및 구현체 InquiryCommandRepositoryAdapter 추가
- 문의 엔티티 Inquiry에 회원 ID, 유형, 제목, 내용, 이메일, 답변 여부 등의 기본 필드 구성

### 3. InquiryQueryApi 및 Controller
- 내 문의 목록 조회 API 인터페이스 InquiryQueryApi 및 컨트롤러 InquiryQueryController 구현
- 커서 기반 페이징을 지원하는 문의 목록 조회

### 4. InquiryQueryService 및 QueryDSL Repository
- 회원 정보 조회 후 QueryDSL 기반 커서 페이징 방식의 문의 목록 조회 로직 구현
- InquiryQueryRepositoryPort 인터페이스 및 InquiryQueryRepositoryAdapter를 통해 데이터 액세스 계층 분리
- QueryDSL로 memberId 필터링, 커서(생성일자 기준) 조건, 페이지 크기 제한 적용


## 🚨 Notes
- 관리자 화면이 피그마 상 없어서 아직 문의 답변 처리 쪽 구현 안 해둔 상태입니다.

## 📟 Related Issues
- Resolved: #183 
