### PR TITLE
[Refactore]  JwtAuthenticationFilter 검증 로직 추가

### DIFF
--- a/src/main/java/talkPick/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/talkPick/global/security/filter/JwtAuthenticationFilter.java
@@ -55,6 +55,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             final var accessToken = authorizationHeader.substring(AuthConstants.BEARER.length());
+            
+            // 토큰 유효성 검증
+            if (!jwtProvider.validateToken(accessToken)) {
+                throw new SecurityExceptionHandler(UNAUTHORIZED);
+            }
+            
             final var memberId = jwtProvider.getMemberIdFromToken(accessToken);
             final var role = jwtProvider.getRoleFromToken(accessToken);
             doAuthentication(accessToken, memberId, role);

--- a/src/main/java/talkPick/global/security/jwt/util/JwtProvider.java
+++ b/src/main/java/talkPick/global/security/jwt/util/JwtProvider.java
@@ -60,9 +60,9 @@ public class JwtProvider {
             Jwts.parserBuilder().setSigningKey(jwtGenerator.getSigningKey()).build().parseClaimsJws(token);
             return true;
         } catch (ExpiredJwtException e) {
-            throw new JwtExceptionHandler(ErrorCode.EXPIRED_JWT_TOKEN);
+            return false;
         } catch (Exception e) {
-            throw new JwtExceptionHandler(ErrorCode.INVALID_JWT_TOKEN);
+            return false;
         }
     }
 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **Branch**
- feature/#190

👷 **Work Done**
JwtAuthenticationFilter 검증 로직 추가

## ✅ Changes
1. JWT 인증 필터 수정 (JwtAuthenticationFilter.java)
변경 전:
토큰 파싱 후 블랙리스트 체크
Bearer 접두사 제거한 토큰만 블랙리스트 검사
토큰 유효성 검증 없이 바로 파싱 시도

변경 후:
```java
// 1. Authorization 헤더 검증
final var authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);

// 2. 블랙리스트 체크 (Bearer 토큰 전체로 검사)
if (redisCommandUseCase.isTokenBlacklisted(authorizationHeader)) {
    throw new SecurityExceptionHandler(UNAUTHORIZED);
}

// 3. 토큰 유효성 검증 추가
if (!jwtProvider.validateToken(accessToken)) {
    throw new SecurityExceptionHandler(UNAUTHORIZED);
}

// 4. 토큰 파싱 및 인증
```

## 🚨 Notes
<!-- Add any notes or considerations here. -->

## 📟 Related Issues
- Resolved: #190 
