### PR TITLE
[Refactor] refreshToken을 HttpOnly 쿠키를 통해 전달하도록 로그인 및 토큰 재발급 로직 개선

### DIFF
--- a/src/main/java/talkPick/domain/member/adapter/in/MemberCommandApi.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/MemberCommandApi.java
@@ -3,6 +3,7 @@ package talkPick.domain.member.adapter.in;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 import talkPick.domain.member.adapter.in.dto.MemberReqDto;
@@ -14,16 +15,16 @@ public interface MemberCommandApi {
     @PostMapping("/kakao/login")
     @Operation(summary = "KAKAO OAuth2 로그인 API", description = "KAKAO OAuth2 로그인 API 입니다.")
     JwtResDTO.Login kakaoOAuth2Login(
-            @Valid @RequestBody MemberReqDto.OAuth2LoginRequest request);
+            @Valid @RequestBody MemberReqDto.OAuth2LoginRequest request, HttpServletResponse response);
 
     @PatchMapping("/apple/login")
     @Operation(summary = "APPLE Oauth2 로그인 API", description = "APPLE OAuth2 로그인 API 입니다.")
-    JwtResDTO.Login appleOauth2Login (@Valid @RequestBody MemberReqDto.OAuth2LoginRequest request);
+    JwtResDTO.Login appleOauth2Login (@Valid @RequestBody MemberReqDto.OAuth2LoginRequest request, HttpServletResponse response);
 
     @PostMapping("/token/refresh")
-    @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰으로 액세스 토큰을 재발급합니다.")
+    @Operation(summary = "액세스 토큰 재발급", description = "쿠키에 담긴 리프레시 토큰으로 액세스 토큰을 재발급합니다.")
     JwtResDTO.AccessToken refreshAccessToken(
-            @Valid @RequestBody MemberReqDto.RefreshAccessTokenRequest request);
+            @CookieValue("refreshToken") String refreshToken);
 
     @PatchMapping("/signup")
     @Operation(summary = "회원가입 완료 API (OAuth 공통 - 회원가입 시 마지막 단계)", description = "회원의 추가 정보(닉네임, MBTI, 성별, 생년월일, 프로필 이미지)를 입력하여 회원가입을 완료하는 API입니다.")

--- a/src/main/java/talkPick/domain/member/adapter/in/MemberCommandController.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/MemberCommandController.java
@@ -1,5 +1,7 @@
 package talkPick.domain.member.adapter.in;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,24 +33,52 @@ public class MemberCommandController implements MemberCommandApi {
 
     @Override
     public JwtResDTO.Login kakaoOAuth2Login(
-            @Valid @RequestBody MemberReqDto.OAuth2LoginRequest request
+            @Valid @RequestBody MemberReqDto.OAuth2LoginRequest request, HttpServletResponse response
     ) {
         MemberDataDto.MemberData kakaoMemberData = kakaoOidcService.verifyAndParseIdToken(request);
         Member member = memberCommandUseCase.findOrCreateMember(kakaoMemberData, LoginType.KAKAO);
-        return jwtTokenCommandUseCase.generateToken(member);
+        JwtResDTO.GeneratedTokens generatedTokens = jwtTokenCommandUseCase.generateToken(member);
+
+        setRefreshTokenCookie(response, generatedTokens.refreshToken(), generatedTokens.refreshExpiredTime());
+
+        return JwtResDTO.Login.of(
+                member.getId(),
+                member.getMemberRole().toString(),
+                generatedTokens.accessToken(),
+                generatedTokens.accessExpiredTime()
+        );
     }
 
-    public JwtResDTO.Login appleOauth2Login (@Valid @RequestBody MemberReqDto.OAuth2LoginRequest request) {
+    public JwtResDTO.Login appleOauth2Login (@Valid @RequestBody MemberReqDto.OAuth2LoginRequest request, HttpServletResponse response) {
         MemberDataDto.MemberData appleMemberData = appleOidcService.verifyAndParseIdToken(request);
         Member member = memberCommandUseCase.findOrCreateMember(appleMemberData, LoginType.APPLE);
-        return jwtTokenCommandUseCase.generateToken(member);
+        JwtResDTO.GeneratedTokens generatedTokens = jwtTokenCommandUseCase.generateToken(member);
+
+        setRefreshTokenCookie(response, generatedTokens.refreshToken(), generatedTokens.refreshExpiredTime());
+
+        return JwtResDTO.Login.of(
+                member.getId(),
+                member.getMemberRole().toString(),
+                generatedTokens.accessToken(),
+                generatedTokens.accessExpiredTime()
+        );
+    }
+
+    // refresh token을 HttpOnly 쿠키로 설정하는 헬퍼 메서드
+    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken, Long refreshExpiredTime) {
+        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true); // HTTPS를 사용하는 프로덕션 환경에서는 true로 설정
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(refreshExpiredTime.intValue());
+        response.addCookie(refreshTokenCookie);
     }
 
     @Override
     public JwtResDTO.AccessToken refreshAccessToken(
-            @Valid @RequestBody MemberReqDto.RefreshAccessTokenRequest request
+            @CookieValue("refreshToken") String refreshToken
     ) {
-        return jwtTokenCommandUseCase.refreshAccessToken(request);
+        return jwtTokenCommandUseCase.refreshAccessToken(refreshToken);
     }
 
     @Override

--- a/src/main/java/talkPick/global/security/jwt/application/JwtTokenCommandService.java
+++ b/src/main/java/talkPick/global/security/jwt/application/JwtTokenCommandService.java
@@ -29,7 +29,7 @@ public class JwtTokenCommandService implements JwtTokenCommandUseCase {
 
     @Override
     @Transactional
-    public JwtResDTO.Login generateToken(Member member) {
+    public JwtResDTO.GeneratedTokens generateToken(Member member) {
         // 1. 새로운 (저장되지 않은) RefreshToken 객체를 생성합니다.
         RefreshToken newRefreshToken = refreshTokenGenerator.generateRefreshToken(member);
 
@@ -53,14 +53,19 @@ public class JwtTokenCommandService implements JwtTokenCommandUseCase {
         JwtResDTO.AccessToken accessToken = jwtGenerator.generateAccessToken(member.getId(), member.getMemberRole().toString());
 
         // 6. 응답 DTO를 생성하여 반환합니다.
-        return JwtResDTO.Login.of(accessToken, refreshTokenToSave);
+        return new JwtResDTO.GeneratedTokens(
+                accessToken.accessToken(),
+                refreshTokenToSave.getToken(),
+                accessToken.accessExpiredTime(),
+                refreshTokenToSave.getExpiredAt().atZone(java.time.ZoneId.systemDefault()).toEpochSecond()
+        );
     }
 
     @Override
     @Transactional
-    public JwtResDTO.AccessToken refreshAccessToken(MemberReqDto.RefreshAccessTokenRequest request) {
+    public JwtResDTO.AccessToken refreshAccessToken(String refreshToken) {
         // DB에서 리프레시 토큰 조회
-        RefreshToken refresh = refreshTokenRepository.findByToken(request.getRefreshToken())
+        RefreshToken refresh = refreshTokenRepository.findByToken(refreshToken)
                 .orElseThrow(() -> new JwtExceptionHandler(ErrorCode.INVALID_REFRESH_TOKEN));
 
         // 리프레시 토큰이 만료됐으면 DB에서 삭제하고 예외 발생

--- a/src/main/java/talkPick/global/security/jwt/dto/JwtResDTO.java
+++ b/src/main/java/talkPick/global/security/jwt/dto/JwtResDTO.java
@@ -1,7 +1,5 @@
 package talkPick.global.security.jwt.dto;
 
-import talkPick.global.security.jwt.RefreshToken;
-
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
@@ -10,18 +8,14 @@ public class JwtResDTO {
             Long memberId,
             String role,
             String accessToken,
-            String refreshToken,
-            Long accessExpiredTime,
-            Long refreshExpiredTime
+            Long accessExpiredTime
     ){
-        public static Login of(final AccessToken accessToken, final RefreshToken refreshToken) {
+        public static Login of(final Long memberId, final String role, final String accessToken, final Long accessExpiredTime) {
             return new Login(
-                    refreshToken.getMember().getId(),
-                    refreshToken.getMember().getMemberRole().toString(),
-                    accessToken.accessToken,
-                    refreshToken.getToken(),
-                    accessToken.accessExpiredTime,
-                    refreshToken.getExpiredAt().atZone(ZoneId.systemDefault()).toEpochSecond()
+                    memberId,
+                    role,
+                    accessToken,
+                    accessExpiredTime
             );
         }
     }
@@ -41,4 +35,11 @@ public class JwtResDTO {
             );
         }
     }
+
+    public record GeneratedTokens(
+        String accessToken,
+        String refreshToken,
+        Long accessExpiredTime,
+        Long refreshExpiredTime
+    ) {}
 }

--- a/src/main/java/talkPick/global/security/jwt/port/in/JwtTokenCommandUseCase.java
+++ b/src/main/java/talkPick/global/security/jwt/port/in/JwtTokenCommandUseCase.java
@@ -5,8 +5,8 @@ import talkPick.domain.member.adapter.in.dto.MemberReqDto;
 import talkPick.global.security.jwt.dto.JwtResDTO;
 
 public interface JwtTokenCommandUseCase {
-    JwtResDTO.Login generateToken(Member member);
-    JwtResDTO.AccessToken refreshAccessToken(MemberReqDto.RefreshAccessTokenRequest request);
+    JwtResDTO.GeneratedTokens generateToken(Member member);
+    JwtResDTO.AccessToken refreshAccessToken(String refreshToken);
 }
 
 

--- a/src/main/java/talkPick/global/security/jwt/util/JwtProvider.java
+++ b/src/main/java/talkPick/global/security/jwt/util/JwtProvider.java
@@ -21,7 +21,6 @@ import static talkPick.global.exception.ErrorCode.ROLE_NOT_FOUND;
 @Component
 public class JwtProvider {
     private final JwtGenerator jwtGenerator;
-    private final RefreshTokenGenerator refreshTokenGenerator;
 
 
     public Long getMemberIdFromToken(String token) {
@@ -85,35 +84,6 @@ public class JwtProvider {
             return Long.valueOf(claims.getSubject());
         } catch (Exception e) {
             throw new JwtExceptionHandler(ErrorCode.INVALID_JWT_TOKEN);
-        }
-    }
-
-    /**
-     * 토큰 만료까지 남은 시간을 밀리초 단위로 반환합니다.
-     */
-    public long getRemainMillis(String authorization) {
-        try {
-            // Bearer 접두사 제거
-            String token = resolveToken(authorization);
-            if (token == null) {
-                return 0;
-            }
-
-            Claims claims = Jwts.parserBuilder()
-                    .setSigningKey(jwtGenerator.getSigningKey())  // JwtGenerator의 키 사용
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody();
-
-            Date expiration = claims.getExpiration();
-            long now = System.currentTimeMillis();
-            long expireTime = expiration.getTime();
-
-            long remain = expireTime - now;
-            return remain > 0 ? remain : 0;
-        } catch (Exception e) {
-            // 토큰이 잘못됐거나 만료된 경우 0 반환
-            return 0;
         }
     }
 }

--- a/src/main/java/talkPick/global/security/jwt/util/JwtProvider.java
+++ b/src/main/java/talkPick/global/security/jwt/util/JwtProvider.java
@@ -24,13 +24,6 @@ public class JwtProvider {
     private final RefreshTokenGenerator refreshTokenGenerator;
 
 
-    public JwtResDTO.Login createJwt(final Member member) {
-        return JwtResDTO.Login.of(
-                jwtGenerator.generateAccessToken(member.getId(), member.getMemberRole().toString()),
-                refreshTokenGenerator.generateRefreshToken(member)
-        );
-    }
-
     public Long getMemberIdFromToken(String token) {
         try {
             var subject = jwtGenerator.parseToken(token).getBody().getSubject();


### PR DESCRIPTION
## 🔥 Pull Request

⛳️ **Branch**
- feature/#243

## 👷 Work Done
  XSS 공격에 대비하기 위해 refreshToken을 HttpOnly 쿠키를 통해 안전하게 전달하도록 로그인 및 토큰 재발급 로직 개선

## ✅ Changes 

   * `refreshToken` HttpOnly 쿠키 도입:
       * kakaoOAuth2Login 및 appleOauth2Login API 응답에서 refreshToken을 JSON 본문 대신 HttpOnly 쿠키로 설정
       * JwtResDTO.Login DTO에서 refreshToken 및 refreshExpiredTime 필드 제거, 클라이언트 응답에는 액세스 토큰 관련 정보만 포함되도록 변경
       * JwtResDTO.GeneratedTokens 내부용 DTO를 추가하여, 토큰 생성 로직(JwtTokenCommandService)에서 컨트롤러 계층으로 accessToken과 refreshToken 정 전달하도록 구조 개선

   * 액세스 토큰 재발급 API(`refreshAccessToken`) 수정:
       * refreshAccessToken API가 요청 본문 대신 클라이언트의 HttpOnly 쿠키에서 refreshToken을 직접 읽어와 액세스 토큰을 재발급하도록 변경
       * MemberCommandApi, JwtTokenCommandUseCase, JwtTokenCommandService, MemberCommandController 관련 메서드 시그니처와 구현 로직을 업데이트

   * 코드 리팩토링:
       * MemberCommandController 내 kakaoOAuth2Login 및 appleOauth2Login 메서드의 중복된 쿠키 설정 로직setRefreshTokenCookie private 헬퍼 메서드로 분리
       * 더 이상 사용되지 않는 JwtProvider.createJwt 메서드를 삭제


## 🚨 Notes

## 📟 Related Issues
- Resolved: #243