### PR TITLE
[Refactor] member 엔티티 gender, profileImageUrl, birth 컬럼 삭제

### DIFF
--- a/src/main/java/talkPick/domain/member/adapter/in/dto/MemberReqDto.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/dto/MemberReqDto.java
@@ -36,12 +36,6 @@ public class MemberReqDto {
         @NotEmpty(message = "닉네임은 필수입니다.")
         @Size(max = 25, message = "닉네임은 최대 25자입니다.")
         private String nickname;
-        @NotNull(message = "성별은 필수입니다.")
-        private Gender gender;
-        @NotNull(message = "생년월일은 필수입니다.")
-        private LocalDate birth;
-        @NotNull(message = "프로필 이미지는 필수입니다.")
-        private String profileImgUrl;
         @NotNull(message = "mbti는 필수입니다.")
         private MBTI mbti;
     }

--- a/src/main/java/talkPick/domain/member/application/MemberCommandService.java
+++ b/src/main/java/talkPick/domain/member/application/MemberCommandService.java
@@ -33,7 +33,6 @@ import java.util.List;
 @Transactional
 @RequiredArgsConstructor
 public class MemberCommandService implements MemberCommandUseCase {
-    private static final String DEFAULT_PROFILE_IMG_URL = "https://example.com/images/default-profile.png";
 
     private final MemberCommandRepositoryPort memberCommandRepositoryPort;
     private final TermQueryRepositoryPort termQueryRepositoryPort;
@@ -88,17 +87,8 @@ public class MemberCommandService implements MemberCommandUseCase {
         }
 
         // 추가 정보 입력
-        findMember.updateBirth(request.getBirth());
-        findMember.updateGender(request.getGender());
         findMember.updateMbti(request.getMbti());
         findMember.updateNickname(request.getNickname());
-
-        String profileImgUrl = request.getProfileImgUrl();
-        if (profileImgUrl == null || profileImgUrl.trim().isEmpty()) {
-            findMember.updateProfileImgUrl(DEFAULT_PROFILE_IMG_URL);
-        } else {
-            findMember.updateProfileImgUrl(profileImgUrl);
-        }
 
         // 회원 ACTIVE 상태 변경
         findMember.updateStatus(TalkPickStatus.ACTIVE);
@@ -218,9 +208,7 @@ public class MemberCommandService implements MemberCommandUseCase {
     // 회원 가입 시 필수 정보 검증
     private boolean validateAdditionalInfo(MemberReqDto.MemberSignupRequest request) {
         return request.getNickname() != null &&
-                request.getMbti() != null &&
-                request.getGender() != null &&
-                request.getBirth() != null;
+                request.getMbti() != null;
     }
 
     // 필수 약관 동의 여부 검증

--- a/src/main/java/talkPick/domain/member/converter/MemberConverter.java
+++ b/src/main/java/talkPick/domain/member/converter/MemberConverter.java
@@ -15,7 +15,6 @@ import talkPick.global.model.TalkPickStatus;
 import java.time.LocalDateTime;
 
 public class MemberConverter {
-    private static final String DEFAULT_PROFILE_IMG_URL = "https://example.com/images/default-profile.png";
     private static final String DEFAULT_NICKNAME = "토픽";
 
     public static MemberDataDto.MemberData toKakaoMemberData(io.jsonwebtoken.Claims claims) {
@@ -30,10 +29,8 @@ public class MemberConverter {
                 .email(MemberData.getEmail())
                 .memberRole(Role.MEMBER)
                 .nickname(DEFAULT_NICKNAME)
-                .gender(Gender.NONE)
                 .loginType(loginType)
                 .status(TalkPickStatus.PENDING)
-                .profileImageUrl(DEFAULT_PROFILE_IMG_URL)
                 .providerId(MemberData.getSub())
                 .build();
 

--- a/src/main/java/talkPick/domain/member/domain/Member.java
+++ b/src/main/java/talkPick/domain/member/domain/Member.java
@@ -54,17 +54,6 @@ public class Member extends BaseTime {
     )
     private String nickname;
 
-    @Column(
-            columnDefinition = "DATE COMMENT '생년월일'"
-    )
-    private LocalDate birth;
-
-    @Enumerated(EnumType.STRING)
-    @Column(
-            columnDefinition = "VARCHAR(10) COMMENT '성별(남/여 등)'"
-    )
-    private Gender gender;
-
     @Enumerated(EnumType.STRING)
     @Column(
             length = 6,
@@ -89,31 +78,12 @@ public class Member extends BaseTime {
 
     @Column(
             length = 255,
-            nullable = false,
-            columnDefinition = "VARCHAR(255) COMMENT '프로필 이미지 URL'"
-    )
-    private String profileImageUrl;
-
-    @Column(
-            length = 255,
             columnDefinition = "VARCHAR(255) COMMENT 'OAuth Provider 식별값(구글, 카카오 등 연결용)'"
     )
     private String providerId;
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
-    }
-
-    public void updateBirth(LocalDate birth) {
-        this.birth = birth;
-    }
-
-    public void updateGender(Gender gender) {
-        this.gender = gender;
-    }
-
-    public void updateProfileImgUrl(String profileImgUrl) {
-        this.profileImageUrl = profileImageUrl;
     }
 
     public void updateMbti(MBTI mbti) {this.mbti = mbti;}

--- a/src/main/java/talkPick/domain/random/dto/MemberDataDTO.java
+++ b/src/main/java/talkPick/domain/random/dto/MemberDataDTO.java
@@ -1,23 +1,12 @@
 package talkPick.domain.random.dto;
 
 import talkPick.domain.member.domain.Member;
-import talkPick.domain.member.domain.type.Gender;
 import talkPick.domain.member.domain.type.MBTI;
 
-import java.time.LocalDate;
-import java.time.Period;
-
 public record MemberDataDTO(
-        MBTI mbti,
-        Gender gender,
-        Integer age
+        MBTI mbti
 ) {
     public static MemberDataDTO from(Member member) {
-        return new MemberDataDTO(member.getMbti(), member.getGender(), calculateAge(member.getBirth()));
-    }
-
-    private static int calculateAge(LocalDate birth) {
-        if (birth == null) return 0;
-        return Period.between(birth, LocalDate.now()).getYears();
+        return new MemberDataDTO(member.getMbti());
     }
 }

--- a/src/main/java/talkPick/domain/topic/domain/TopicStat.java
+++ b/src/main/java/talkPick/domain/topic/domain/TopicStat.java
@@ -95,13 +95,6 @@ public class TopicStat {
                 .averageTalkTime(0)
                 .selectCount(0)
                 .likeCount(0)
-                .teenCount(0)
-                .twentiesCount(0)
-                .thirtiesCount(0)
-                .fortiesCount(0)
-                .fiftiesCount(0)
-                .maleCount(0)
-                .femaleCount(0)
                 .build();
     }
 
@@ -113,8 +106,6 @@ public class TopicStat {
     public void update(Member member, long talkTime) {
         MBTI mbti = MBTI.INFP;
         updateMBTI(mbti);
-        updateAge(member.getBirth());
-        updateGender(member.getGender());
         updateAverageTalkTime(talkTime);
         this.selectCount++;
     }
@@ -141,34 +132,6 @@ public class TopicStat {
                 this.jCount++;
             } else if (mbtiString.charAt(3) == 'P') {
                 this.pCount++;
-            }
-        }
-    }
-
-    private void updateAge(LocalDate birth) {
-        if (birth != null) {
-            int age = LocalDate.now().getYear() - birth.getYear();
-
-            if (age < 20) {
-                this.teenCount++;
-            } else if (age < 30) {
-                this.twentiesCount++;
-            } else if (age < 40) {
-                this.thirtiesCount++;
-            } else if (age < 50) {
-                this.fortiesCount++;
-            } else {
-                this.fiftiesCount++;
-            }
-        }
-    }
-
-    private void updateGender(Gender gender) {
-        if (gender != null) {
-            if (gender == Gender.MALE) {
-                this.maleCount++;
-            } else if (gender == Gender.FEMALE) {
-                this.femaleCount++;
             }
         }
     }


### PR DESCRIPTION
## 🔥 Pull Request

⛳️ **Branch**
- feature/#250

👷 **Work Done**
- member 엔티티 gender, profileImageUrl, birth 컬럼 삭제 및 관련 코드 수정
- TopicStat 내부에서 해당 토픽을 선택한 연령층, 성별 통계 추적 코드 제거

## ✅ Changes
- **`Member`**: 필드 및 관련  메서드 제거                                                                                                                      
  - **`MemberReqDto`**:  DTO에서  관련  필드 제거           
  - **`MemberCommandService`**:  상수 제거,  및  메서드 수정
  - **`MemberConverter`**:  상수 제거,  메서드 수정
  - **`MemberDataDTO`**: ,  필드 및  메서드 제거,  메서드 수정
- **`TopicStat`**: 연령/성별 통계 필드 및 관련  메서드와  메서드 초기화 로직 제거
## 🚨 Notes
<!-- 리뷰 시 참고해야 할 내용, 고려사항 기입 -->

## 📟 Related Issues
- Resolved: #250 