### PR TITLE
[Refactor] 회원 삭제 시 방식 변경

### DIFF
--- a/src/main/java/talkPick/domain/inquiry/adapter/out/repository/InquiryJpaRepository.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/out/repository/InquiryJpaRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import talkPick.domain.inquiry.domain.Inquiry;
 
 public interface InquiryJpaRepository extends JpaRepository<Inquiry, Long> {
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/talkPick/domain/member/adapter/out/MemberTermCommandRepositoryAdapter.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/MemberTermCommandRepositoryAdapter.java
@@ -22,6 +22,11 @@ public class MemberTermCommandRepositoryAdapter implements MemberTermCommandRepo
     public MemberTerm save(MemberTerm memberTerm) {
         return repository.save(memberTerm);
     }
+
+    @Override
+    public void deleteByMemberId(Long memberId) {
+        repository.deleteByMemberId(memberId);
+    }
 }
 
 

--- a/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTermJpaRepository.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTermJpaRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 public interface MemberTermJpaRepository extends JpaRepository<MemberTerm, Long> {
     // 특정 약관 및 유저의 동의 상태 조회
     Optional<MemberTerm> findByMemberIdAndTermId(Long memberId, Long termId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicHistoryJpaRepository.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicHistoryJpaRepository.java
@@ -1,0 +1,8 @@
+package talkPick.domain.member.adapter.out.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import talkPick.domain.topic.domain.member.MemberTopicHistory;
+
+public interface MemberTopicHistoryJpaRepository extends JpaRepository<MemberTopicHistory, Long> {
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicResultJpaRepository.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicResultJpaRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface MemberTopicResultJpaRepository extends JpaRepository<MemberTopicResult, Long> {
     Optional<MemberTopicResult> findByMemberTopicHistoryId(Long memberTopicHistoryId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/talkPick/domain/member/application/MemberCommandService.java
+++ b/src/main/java/talkPick/domain/member/application/MemberCommandService.java
@@ -1,9 +1,9 @@
 package talkPick.domain.member.application;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import talkPick.domain.member.adapter.out.repository.MemberJpaRepository;
 import talkPick.domain.member.port.out.MemberCommandRepositoryPort;
 import talkPick.domain.member.port.out.MemberTermCommandRepositoryPort;
 import talkPick.domain.member.adapter.out.repository.MemberTopicResultJpaRepository;
@@ -26,6 +26,12 @@ import talkPick.global.exception.handler.MemberExceptionHandler;
 import talkPick.global.exception.handler.TermExceptionHandler;
 import talkPick.global.model.TalkPickStatus;
 import talkPick.global.security.jwt.util.JwtProvider;
+import talkPick.domain.inquiry.adapter.out.repository.InquiryJpaRepository;
+import talkPick.domain.random.adapter.out.repository.RandomJpaRepository;
+import talkPick.domain.random.adapter.out.repository.RandomTopicHistoryJpaRepository;
+import talkPick.domain.today.adapter.out.repository.TodayTopicJpaRepository;
+import talkPick.domain.topic.adapter.out.repository.TopicLikeHistoryJpaRepository;
+import talkPick.domain.member.adapter.out.repository.MemberTopicHistoryJpaRepository;
 
 import java.util.List;
 
@@ -42,6 +48,14 @@ public class MemberCommandService implements MemberCommandUseCase {
     private final MemberQueryRepositoryPort memberQueryRepositoryPort;
     private final JwtProvider jwtProvider;
     private final MemberTopicResultJpaRepository memberTopicResultJpaRepository;
+    private final MemberJpaRepository memberJpaRepository;
+    private final InquiryJpaRepository inquiryJpaRepository;
+    private final RandomJpaRepository randomJpaRepository;
+    private final RandomTopicHistoryJpaRepository randomTopicHistoryJpaRepository;
+    private final TodayTopicJpaRepository todayTopicJpaRepository;
+    private final TopicLikeHistoryJpaRepository topicLikeHistoryJpaRepository;
+    private final MemberTopicHistoryJpaRepository memberTopicHistoryJpaRepository;
+
 
     /**
      * 회원 프로필 수정
@@ -93,11 +107,6 @@ public class MemberCommandService implements MemberCommandUseCase {
         // 회원 ACTIVE 상태 변경
         findMember.updateStatus(TalkPickStatus.ACTIVE);
         memberCommandRepositoryPort.save(findMember);
-
-        // 이메일 회원은 임시 토큰 삭제 처리
-//        if (findMember.getLoginType() == LoginType.EMAIL) {
-//            refreshTokenRepository.findByMember(findMember).ifPresent(refreshTokenRepository::delete);
-//        }
 
         // 소셜 로그인 회원 가입 완료 시 로그인 기록 저장
         if (findMember.getLoginType() == LoginType.KAKAO || findMember.getLoginType() == LoginType.APPLE) {
@@ -179,8 +188,23 @@ public class MemberCommandService implements MemberCommandUseCase {
 
         refreshTokenRepository.findByMember(findMember).ifPresent(refreshTokenRepository::delete);
 
+        // 연관 데이터 삭제
+        deleteAllRelatedData(findMember.getId());
+
         // 로그인 기록 삭제
         memberLoginHistoryRepository.deleteByMemberId(findMember.getId());
+        memberJpaRepository.deleteById(findMember.getId());
+    }
+
+    private void deleteAllRelatedData(Long memberId) {
+        inquiryJpaRepository.deleteByMemberId(memberId);
+        memberTermJpaRepository.deleteByMemberId(memberId);
+        memberTopicResultJpaRepository.deleteByMemberId(memberId);
+        randomTopicHistoryJpaRepository.deleteByMemberId(memberId);
+        randomJpaRepository.deleteByMemberId(memberId);
+        todayTopicJpaRepository.deleteByMemberId(memberId);
+        topicLikeHistoryJpaRepository.deleteByMemberId(memberId);
+        memberTopicHistoryJpaRepository.deleteByMemberId(memberId);
     }
 
     // 토픽 캘린더 조회 코멘트 수정

--- a/src/main/java/talkPick/domain/member/port/out/MemberTermCommandRepositoryPort.java
+++ b/src/main/java/talkPick/domain/member/port/out/MemberTermCommandRepositoryPort.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 public interface MemberTermCommandRepositoryPort {
     Optional<MemberTerm> findByMemberIdAndTermId(Long memberId, Long termId);
     MemberTerm save(MemberTerm memberTerm);
+    void deleteByMemberId(Long memberId);
 }
 
 

--- a/src/main/java/talkPick/domain/random/adapter/out/repository/RandomJpaRepository.java
+++ b/src/main/java/talkPick/domain/random/adapter/out/repository/RandomJpaRepository.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 
 public interface RandomJpaRepository extends JpaRepository<Random, Long> {
     Optional<Random> findRandomByMemberIdAndId(Long memberId, Long randomId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/talkPick/domain/random/adapter/out/repository/RandomTopicHistoryJpaRepository.java
+++ b/src/main/java/talkPick/domain/random/adapter/out/repository/RandomTopicHistoryJpaRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface RandomTopicHistoryJpaRepository extends JpaRepository<RandomTopicHistory, Long> {
     Optional<RandomTopicHistory> findByMemberIdAndRandomIdAndOrder(Long memberId, Long randomId, Integer order);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/talkPick/domain/today/adapter/out/repository/TodayTopicJpaRepository.java
+++ b/src/main/java/talkPick/domain/today/adapter/out/repository/TodayTopicJpaRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import talkPick.domain.today.domain.TodayTopic;
 
 public interface TodayTopicJpaRepository extends JpaRepository<TodayTopic, Long> {
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/talkPick/domain/topic/adapter/out/repository/TopicLikeHistoryJpaRepository.java
+++ b/src/main/java/talkPick/domain/topic/adapter/out/repository/TopicLikeHistoryJpaRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import talkPick.domain.topic.domain.TopicLikeHistory;
 
 public interface TopicLikeHistoryJpaRepository extends JpaRepository<TopicLikeHistory, Long> {
+    void deleteByMemberId(Long memberId);
 }

--- a/src/test/java/talkPick/domain/member/application/MemberDeleteVerificationTest.java
+++ b/src/test/java/talkPick/domain/member/application/MemberDeleteVerificationTest.java
@@ -1,0 +1,87 @@
+package talkPick.domain.member.application;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import talkPick.domain.inquiry.adapter.out.repository.InquiryJpaRepository;
+import talkPick.domain.member.adapter.out.repository.MemberJpaRepository;
+import talkPick.domain.member.adapter.out.repository.MemberTopicResultJpaRepository;
+import talkPick.domain.member.domain.Member;
+import talkPick.domain.member.port.out.MemberCommandRepositoryPort;
+import talkPick.domain.member.port.out.MemberLoginHistoryCommandRepositoryPort;
+import talkPick.domain.member.port.out.MemberQueryRepositoryPort;
+import talkPick.domain.member.port.out.MemberTermCommandRepositoryPort;
+import talkPick.domain.random.adapter.out.repository.RandomJpaRepository;
+import talkPick.domain.random.adapter.out.repository.RandomTopicHistoryJpaRepository;
+import talkPick.domain.term.port.out.TermQueryRepositoryPort;
+import talkPick.domain.today.adapter.out.repository.TodayTopicJpaRepository;
+import talkPick.domain.member.adapter.out.repository.MemberTopicHistoryJpaRepository;
+import talkPick.domain.topic.adapter.out.repository.TopicLikeHistoryJpaRepository;
+import talkPick.global.security.jwt.repository.RefreshTokenRepository;
+import talkPick.global.security.jwt.util.JwtProvider;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MemberDeleteVerificationTest {
+
+    @InjectMocks
+    private MemberCommandService memberCommandService;
+
+    @Mock private MemberCommandRepositoryPort memberCommandRepositoryPort;
+    @Mock private TermQueryRepositoryPort termQueryRepositoryPort;
+    @Mock private MemberTermCommandRepositoryPort memberTermJpaRepository;
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private MemberLoginHistoryCommandRepositoryPort memberLoginHistoryRepository;
+    @Mock private MemberQueryRepositoryPort memberQueryRepositoryPort;
+    @Mock private JwtProvider jwtProvider;
+    @Mock private MemberTopicResultJpaRepository memberTopicResultJpaRepository;
+    @Mock private MemberJpaRepository memberJpaRepository;
+    @Mock private InquiryJpaRepository inquiryJpaRepository;
+    @Mock private RandomJpaRepository randomJpaRepository;
+    @Mock private RandomTopicHistoryJpaRepository randomTopicHistoryJpaRepository;
+    @Mock private TodayTopicJpaRepository todayTopicJpaRepository;
+    @Mock private TopicLikeHistoryJpaRepository topicLikeHistoryJpaRepository;
+    @Mock private MemberTopicHistoryJpaRepository memberTopicHistoryJpaRepository;
+
+    @Test
+    @DisplayName("회원 탈퇴 시 모든 연관 데이터가 삭제되어야 한다")
+    void delete_shouldDeleteAllRelatedData() {
+        // given
+        String token = "Bearer token";
+        Long memberId = 1L;
+        Member mockMember = mock(Member.class);
+        given(mockMember.getId()).willReturn(memberId);
+
+        given(jwtProvider.getMemberId(token)).willReturn(memberId);
+        given(memberQueryRepositoryPort.findMemberById(memberId)).willReturn(mockMember);
+        given(refreshTokenRepository.findByMember(mockMember)).willReturn(Optional.empty());
+
+        // when
+        memberCommandService.delete(token);
+
+        // then
+        // 기존 삭제 로직 검증
+        verify(memberLoginHistoryRepository).deleteByMemberId(memberId);
+        verify(memberJpaRepository).deleteById(memberId);
+
+        // 누락되었던 삭제 로직 검증
+        verify(inquiryJpaRepository).deleteByMemberId(memberId);
+        verify(memberTermJpaRepository).deleteByMemberId(memberId);
+        verify(memberTopicResultJpaRepository).deleteByMemberId(memberId);
+        verify(randomJpaRepository).deleteByMemberId(memberId);
+        verify(randomTopicHistoryJpaRepository).deleteByMemberId(memberId);
+        verify(todayTopicJpaRepository).deleteByMemberId(memberId);
+        verify(topicLikeHistoryJpaRepository).deleteByMemberId(memberId);
+        verify(memberTopicHistoryJpaRepository).deleteByMemberId(memberId);
+    }
+}


### PR DESCRIPTION
## 🔥 Pull Request

⛳️ **Branch**
- feature/#253

👷 **Work Done**
- 회원 탈퇴 시 소프트 삭제 -> 하드 방식으로 변경

## ✅ Changes
- 회원 탈퇴 시 연관 데이터 삭제를 위해 연관 데이터 레포지토리에 deleteById JPA 메서드 추가

## 🚨 Notes
<!-- 리뷰 시 참고해야 할 내용, 고려사항 기입 -->

## 📟 Related Issues
- Resolved: #253 