### PR TITLE
[Refactor] 회원 탈퇴 시 벌크 연산 및 퍼사드 패턴 적용

### DIFF
--- a/src/main/java/talkPick/domain/inquiry/adapter/out/repository/InquiryJpaRepository.java
+++ b/src/main/java/talkPick/domain/inquiry/adapter/out/repository/InquiryJpaRepository.java
@@ -1,8 +1,15 @@
 package talkPick.domain.inquiry.adapter.out.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import talkPick.domain.inquiry.domain.Inquiry;
 
 public interface InquiryJpaRepository extends JpaRepository<Inquiry, Long> {
     void deleteByMemberId(Long memberId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Inquiry i WHERE i.memberId = :memberId")
+    void deleteAllByMemberIdInBulk(@Param("memberId") Long memberId);
 }

--- a/src/main/java/talkPick/domain/member/adapter/in/MemberCommandController.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/MemberCommandController.java
@@ -15,6 +15,7 @@ import talkPick.global.security.jwt.dto.JwtResDTO;
 import talkPick.domain.member.domain.Member;
 import talkPick.domain.member.dto.*;
 import talkPick.domain.member.port.in.MemberCommandUseCase;
+import talkPick.domain.member.port.in.MemberWithdrawalUseCase;
 import talkPick.global.security.jwt.port.in.JwtTokenCommandUseCase;
 
 /**
@@ -28,6 +29,7 @@ public class MemberCommandController implements MemberCommandApi {
     private final KakaoOidcUsecase kakaoOidcService;
     private final AppleOidcUsecase appleOidcService;
     private final MemberCommandUseCase memberCommandUseCase;
+    private final MemberWithdrawalUseCase memberWithdrawalUseCase; // 의존성 추가
     private final JwtTokenCommandUseCase jwtTokenCommandUseCase;
 
 
@@ -116,7 +118,8 @@ public class MemberCommandController implements MemberCommandApi {
     public void deleteMember(
             @RequestHeader(value = "Authorization", required = false) String authorization
     ) {
-        memberCommandUseCase.delete(authorization);
+        // Facade 서비스 호출로 변경
+        memberWithdrawalUseCase.withdraw(authorization);
     }
 
     @Override
@@ -125,7 +128,5 @@ public class MemberCommandController implements MemberCommandApi {
             @Valid @RequestBody MemberReqDto.TopicResultCommentChangeRequest request) {
         memberCommandUseCase.TopicResultCommentChange(authorization, request);
     }
-
-
 
 }

--- a/src/main/java/talkPick/domain/member/adapter/out/repository/MemberLoginHistoryJpaRepository.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/repository/MemberLoginHistoryJpaRepository.java
@@ -1,8 +1,15 @@
 package talkPick.domain.member.adapter.out.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import talkPick.domain.member.domain.MemberLoginHistory;
 
 public interface MemberLoginHistoryJpaRepository extends JpaRepository<MemberLoginHistory, Long> {
     void deleteByMemberId(Long memberId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM MemberLoginHistory m WHERE m.memberId = :memberId")
+    void deleteAllByMemberIdInBulk(@Param("memberId") Long memberId);
 }

--- a/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTermJpaRepository.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTermJpaRepository.java
@@ -1,8 +1,10 @@
 package talkPick.domain.member.adapter.out.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import talkPick.domain.member.domain.mapping.MemberTerm;
-import talkPick.domain.term.domain.Term;
 
 import java.util.Optional;
 
@@ -11,4 +13,8 @@ public interface MemberTermJpaRepository extends JpaRepository<MemberTerm, Long>
     Optional<MemberTerm> findByMemberIdAndTermId(Long memberId, Long termId);
 
     void deleteByMemberId(Long memberId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM MemberTerm m WHERE m.memberId = :memberId")
+    void deleteAllByMemberIdInBulk(@Param("memberId") Long memberId);
 }

--- a/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicHistoryJpaRepository.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicHistoryJpaRepository.java
@@ -1,8 +1,15 @@
 package talkPick.domain.member.adapter.out.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import talkPick.domain.topic.domain.member.MemberTopicHistory;
 
 public interface MemberTopicHistoryJpaRepository extends JpaRepository<MemberTopicHistory, Long> {
     void deleteByMemberId(Long memberId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM MemberTopicHistory m WHERE m.memberId = :memberId")
+    void deleteAllByMemberIdInBulk(@Param("memberId") Long memberId);
 }

--- a/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicResultJpaRepository.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/repository/MemberTopicResultJpaRepository.java
@@ -1,6 +1,9 @@
 package talkPick.domain.member.adapter.out.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import talkPick.domain.topic.domain.member.MemberTopicResult;
 
 import java.util.Optional;
@@ -9,4 +12,8 @@ public interface MemberTopicResultJpaRepository extends JpaRepository<MemberTopi
     Optional<MemberTopicResult> findByMemberTopicHistoryId(Long memberTopicHistoryId);
 
     void deleteByMemberId(Long memberId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM MemberTopicResult m WHERE m.memberId = :memberId")
+    void deleteAllByMemberIdInBulk(@Param("memberId") Long memberId);
 }

--- a/src/main/java/talkPick/domain/member/application/MemberCommandService.java
+++ b/src/main/java/talkPick/domain/member/application/MemberCommandService.java
@@ -3,7 +3,6 @@ package talkPick.domain.member.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import talkPick.domain.member.adapter.out.repository.MemberJpaRepository;
 import talkPick.domain.member.port.out.MemberCommandRepositoryPort;
 import talkPick.domain.member.port.out.MemberTermCommandRepositoryPort;
 import talkPick.domain.member.adapter.out.repository.MemberTopicResultJpaRepository;
@@ -15,6 +14,7 @@ import talkPick.domain.member.dto.MemberDataDto;
 import talkPick.domain.member.adapter.in.dto.MemberReqDto;
 import talkPick.domain.member.adapter.out.dto.MemberResDto;
 import talkPick.domain.member.port.in.MemberCommandUseCase;
+import talkPick.domain.member.port.in.MemberWithdrawalUseCase;
 import talkPick.domain.member.port.out.MemberLoginHistoryCommandRepositoryPort;
 import talkPick.domain.member.port.out.MemberQueryRepositoryPort;
 import talkPick.domain.term.port.out.TermQueryRepositoryPort;
@@ -26,12 +26,7 @@ import talkPick.global.exception.handler.MemberExceptionHandler;
 import talkPick.global.exception.handler.TermExceptionHandler;
 import talkPick.global.model.TalkPickStatus;
 import talkPick.global.security.jwt.util.JwtProvider;
-import talkPick.domain.inquiry.adapter.out.repository.InquiryJpaRepository;
-import talkPick.domain.random.adapter.out.repository.RandomJpaRepository;
-import talkPick.domain.random.adapter.out.repository.RandomTopicHistoryJpaRepository;
-import talkPick.domain.today.adapter.out.repository.TodayTopicJpaRepository;
-import talkPick.domain.topic.adapter.out.repository.TopicLikeHistoryJpaRepository;
-import talkPick.domain.member.adapter.out.repository.MemberTopicHistoryJpaRepository;
+
 
 import java.util.List;
 
@@ -46,15 +41,9 @@ public class MemberCommandService implements MemberCommandUseCase {
     private final RefreshTokenRepository refreshTokenRepository;
     private final MemberLoginHistoryCommandRepositoryPort memberLoginHistoryRepository;
     private final MemberQueryRepositoryPort memberQueryRepositoryPort;
+    private final MemberWithdrawalUseCase memberWithdrawalUseCase;
     private final JwtProvider jwtProvider;
     private final MemberTopicResultJpaRepository memberTopicResultJpaRepository;
-    private final MemberJpaRepository memberJpaRepository;
-    private final InquiryJpaRepository inquiryJpaRepository;
-    private final RandomJpaRepository randomJpaRepository;
-    private final RandomTopicHistoryJpaRepository randomTopicHistoryJpaRepository;
-    private final TodayTopicJpaRepository todayTopicJpaRepository;
-    private final TopicLikeHistoryJpaRepository topicLikeHistoryJpaRepository;
-    private final MemberTopicHistoryJpaRepository memberTopicHistoryJpaRepository;
 
 
     /**
@@ -176,35 +165,10 @@ public class MemberCommandService implements MemberCommandUseCase {
         memberLoginHistoryRepository.deleteByMemberId(findMember.getId());
     }
 
-    // 회원 탈퇴 처리 (상태 비활성화, 토큰 및 로그인 기록 삭제)
+    // 회원 탈퇴 처리
     @Override
     public void delete(String authorization) {
-        Long memberId = jwtProvider.getMemberId(authorization);
-
-        Member findMember = memberQueryRepositoryPort.findMemberById(memberId);
-
-        findMember.updateStatus(TalkPickStatus.DIS_ACTIVE);
-        memberCommandRepositoryPort.save(findMember);
-
-        refreshTokenRepository.findByMember(findMember).ifPresent(refreshTokenRepository::delete);
-
-        // 연관 데이터 삭제
-        deleteAllRelatedData(findMember.getId());
-
-        // 로그인 기록 삭제
-        memberLoginHistoryRepository.deleteByMemberId(findMember.getId());
-        memberJpaRepository.deleteById(findMember.getId());
-    }
-
-    private void deleteAllRelatedData(Long memberId) {
-        inquiryJpaRepository.deleteByMemberId(memberId);
-        memberTermJpaRepository.deleteByMemberId(memberId);
-        memberTopicResultJpaRepository.deleteByMemberId(memberId);
-        randomTopicHistoryJpaRepository.deleteByMemberId(memberId);
-        randomJpaRepository.deleteByMemberId(memberId);
-        todayTopicJpaRepository.deleteByMemberId(memberId);
-        topicLikeHistoryJpaRepository.deleteByMemberId(memberId);
-        memberTopicHistoryJpaRepository.deleteByMemberId(memberId);
+        memberWithdrawalUseCase.withdraw(authorization);
     }
 
     // 토픽 캘린더 조회 코멘트 수정

--- a/src/main/java/talkPick/domain/member/application/MemberWithdrawalService.java
+++ b/src/main/java/talkPick/domain/member/application/MemberWithdrawalService.java
@@ -1,0 +1,61 @@
+package talkPick.domain.member.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import talkPick.domain.inquiry.adapter.out.repository.InquiryJpaRepository;
+import talkPick.domain.member.adapter.out.repository.MemberJpaRepository;
+import talkPick.domain.member.adapter.out.repository.MemberLoginHistoryJpaRepository;
+import talkPick.domain.member.adapter.out.repository.MemberTermJpaRepository;
+import talkPick.domain.member.adapter.out.repository.MemberTopicHistoryJpaRepository;
+import talkPick.domain.member.adapter.out.repository.MemberTopicResultJpaRepository;
+import talkPick.domain.member.port.in.MemberWithdrawalUseCase;
+import talkPick.domain.random.adapter.out.repository.RandomJpaRepository;
+import talkPick.domain.random.adapter.out.repository.RandomTopicHistoryJpaRepository;
+import talkPick.domain.today.adapter.out.repository.TodayTopicJpaRepository;
+import talkPick.domain.topic.adapter.out.repository.TopicLikeHistoryJpaRepository;
+import talkPick.global.security.jwt.repository.RefreshTokenRepository;
+import talkPick.global.security.jwt.util.JwtProvider;
+
+@Service
+@RequiredArgsConstructor
+public class MemberWithdrawalService implements MemberWithdrawalUseCase {
+
+    private final JwtProvider jwtProvider;
+    private final MemberJpaRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    
+    // 연관 데이터 리포지토리들
+    private final InquiryJpaRepository inquiryRepository;
+    private final MemberTermJpaRepository memberTermRepository;
+    private final MemberLoginHistoryJpaRepository memberLoginHistoryRepository;
+    private final MemberTopicHistoryJpaRepository memberTopicHistoryRepository;
+    private final MemberTopicResultJpaRepository memberTopicResultRepository;
+    private final RandomJpaRepository randomRepository;
+    private final RandomTopicHistoryJpaRepository randomTopicHistoryRepository;
+    private final TodayTopicJpaRepository todayTopicRepository;
+    private final TopicLikeHistoryJpaRepository topicLikeHistoryRepository;
+
+    @Override
+    @Transactional
+    public void withdraw(String authorization) {
+        Long memberId = jwtProvider.getMemberId(authorization);
+
+        // 1. Refresh Token 삭제
+        refreshTokenRepository.deleteAllByMemberIdInBulk(memberId);
+
+        // 2. 연관 데이터 일괄 삭제
+        inquiryRepository.deleteAllByMemberIdInBulk(memberId);
+        memberTermRepository.deleteAllByMemberIdInBulk(memberId);
+        memberLoginHistoryRepository.deleteAllByMemberIdInBulk(memberId);
+        memberTopicHistoryRepository.deleteAllByMemberIdInBulk(memberId);
+        memberTopicResultRepository.deleteAllByMemberIdInBulk(memberId);
+        randomRepository.deleteAllByMemberIdInBulk(memberId);
+        randomTopicHistoryRepository.deleteAllByMemberIdInBulk(memberId);
+        todayTopicRepository.deleteAllByMemberIdInBulk(memberId);
+        topicLikeHistoryRepository.deleteAllByMemberIdInBulk(memberId);
+
+        // 3. 회원 삭제
+        memberRepository.deleteById(memberId);
+    }
+}

--- a/src/main/java/talkPick/domain/member/port/in/MemberCommandUseCase.java
+++ b/src/main/java/talkPick/domain/member/port/in/MemberCommandUseCase.java
@@ -7,13 +7,11 @@ import talkPick.domain.member.adapter.in.dto.MemberReqDto;
 import talkPick.domain.member.adapter.out.dto.MemberResDto;
 
 public interface MemberCommandUseCase {
-//    Member findOrCreateEmailMember(MemberReqDto.MemberEmailRequest emailReqDto);
-//    Member loginEmailMember(MemberReqDto.MemberEmailRequest emailReqDto);
     MemberResDto.MemberProfileResponse updateProfile(String authorization, MemberReqDto.ProfileUpdateRequest request);
     Member findOrCreateMember(MemberDataDto.MemberData kakaoMemberData, LoginType loginType);
     MemberResDto.MemberSignupResponse memberSignup(String authorization, MemberReqDto.MemberSignupRequest request);
     MemberResDto.TermAgreementResponse termAgreement(String authorization, MemberReqDto.TermAgreementRequest request);
     void logout(String authorization);
-    void delete(String authorization);
     void TopicResultCommentChange(String authorization, MemberReqDto.TopicResultCommentChangeRequest request);
+    void delete(String authorization);
 }

--- a/src/main/java/talkPick/domain/member/port/in/MemberWithdrawalUseCase.java
+++ b/src/main/java/talkPick/domain/member/port/in/MemberWithdrawalUseCase.java
@@ -1,0 +1,5 @@
+package talkPick.domain.member.port.in;
+
+public interface MemberWithdrawalUseCase {
+    void withdraw(String authorization);
+}

--- a/src/main/java/talkPick/domain/random/adapter/out/repository/RandomJpaRepository.java
+++ b/src/main/java/talkPick/domain/random/adapter/out/repository/RandomJpaRepository.java
@@ -1,6 +1,9 @@
 package talkPick.domain.random.adapter.out.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import talkPick.domain.random.domain.Random;
 import java.util.Optional;
 
@@ -8,4 +11,8 @@ public interface RandomJpaRepository extends JpaRepository<Random, Long> {
     Optional<Random> findRandomByMemberIdAndId(Long memberId, Long randomId);
 
     void deleteByMemberId(Long memberId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Random r WHERE r.memberId = :memberId")
+    void deleteAllByMemberIdInBulk(@Param("memberId") Long memberId);
 }

--- a/src/main/java/talkPick/domain/random/adapter/out/repository/RandomTopicHistoryJpaRepository.java
+++ b/src/main/java/talkPick/domain/random/adapter/out/repository/RandomTopicHistoryJpaRepository.java
@@ -1,6 +1,9 @@
 package talkPick.domain.random.adapter.out.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import talkPick.domain.random.domain.RandomTopicHistory;
 
 import java.util.Optional;
@@ -9,4 +12,8 @@ public interface RandomTopicHistoryJpaRepository extends JpaRepository<RandomTop
     Optional<RandomTopicHistory> findByMemberIdAndRandomIdAndOrder(Long memberId, Long randomId, Integer order);
 
     void deleteByMemberId(Long memberId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM RandomTopicHistory r WHERE r.memberId = :memberId")
+    void deleteAllByMemberIdInBulk(@Param("memberId") Long memberId);
 }

--- a/src/main/java/talkPick/domain/today/adapter/out/repository/TodayTopicJpaRepository.java
+++ b/src/main/java/talkPick/domain/today/adapter/out/repository/TodayTopicJpaRepository.java
@@ -1,8 +1,15 @@
 package talkPick.domain.today.adapter.out.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import talkPick.domain.today.domain.TodayTopic;
 
 public interface TodayTopicJpaRepository extends JpaRepository<TodayTopic, Long> {
     void deleteByMemberId(Long memberId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM TodayTopic t WHERE t.memberId = :memberId")
+    void deleteAllByMemberIdInBulk(@Param("memberId") Long memberId);
 }

--- a/src/main/java/talkPick/domain/topic/adapter/out/repository/TopicLikeHistoryJpaRepository.java
+++ b/src/main/java/talkPick/domain/topic/adapter/out/repository/TopicLikeHistoryJpaRepository.java
@@ -1,8 +1,15 @@
 package talkPick.domain.topic.adapter.out.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import talkPick.domain.topic.domain.TopicLikeHistory;
 
 public interface TopicLikeHistoryJpaRepository extends JpaRepository<TopicLikeHistory, Long> {
     void deleteByMemberId(Long memberId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM TopicLikeHistory t WHERE t.memberId = :memberId")
+    void deleteAllByMemberIdInBulk(@Param("memberId") Long memberId);
 }

--- a/src/main/java/talkPick/global/security/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/talkPick/global/security/jwt/repository/RefreshTokenRepository.java
@@ -1,6 +1,9 @@
 package talkPick.global.security.jwt.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import talkPick.domain.member.domain.Member;
 import talkPick.global.security.jwt.RefreshToken;
@@ -13,4 +16,8 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByMember(Member member);
     Optional<RefreshToken> findByMemberId(Long memberId);
     void deleteByMember(Member member);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM RefreshToken r WHERE r.member.id = :memberId")
+    void deleteAllByMemberIdInBulk(@Param("memberId") Long memberId);
 }

--- a/src/test/java/talkPick/performance/ConnectionPoolTest.java
+++ b/src/test/java/talkPick/performance/ConnectionPoolTest.java
@@ -1,0 +1,82 @@
+package talkPick.performance;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.util.StopWatch;
+
+import javax.sql.DataSource;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@SpringBootTest
+@Import(PerformanceTestService.class)
+public class ConnectionPoolTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ConnectionPoolTest.class);
+
+    @Autowired
+    private PerformanceTestService performanceTestService;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    @DisplayName("커넥션 풀 사이즈와 컨텍스트 스위칭 성능 테스트")
+    void testConnectionPoolPerformance() throws InterruptedException {
+        // 1. 현재 HikariCP 설정 확인
+        HikariDataSource hikariDataSource = (HikariDataSource) dataSource;
+        int currentPoolSize = hikariDataSource.getMaximumPoolSize();
+        log.info("==================================================");
+        log.info("현재 HikariCP Maximum Pool Size: {}", currentPoolSize);
+        log.info("==================================================");
+
+        // 테스트 설정
+        int threadCount = 3000; // 동시 요청 스레드 수
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        StopWatch stopWatch = new StopWatch();
+
+        log.info("테스트 시작: {}개의 동시 요청 실행 중...", threadCount);
+        stopWatch.start();
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                try {
+                    performanceTestService.heavyWork();
+                } catch (Exception e) {
+                    log.error("테스트 중 예외 발생", e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // 모든 스레드가 끝날 때까지 대기
+        latch.await();
+        stopWatch.stop();
+
+        log.info("==================================================");
+        log.info("테스트 완료");
+        log.info("총 소요 시간: {} ms", stopWatch.getTotalTimeMillis());
+        log.info("초당 처리량(TPS): {}", threadCount / stopWatch.getTotalTimeSeconds());
+        log.info("==================================================");
+        
+        /* 
+         * [테스트 가이드]
+         * 1. application.yml 또는 환경변수에서 'maximum-pool-size'를 10으로 설정 후 실행해 보세요.
+         * 2. 그 다음, 200으로 설정 후 실행해 보세요.
+         * 
+         * 예상 결과:
+         * - Pool Size 10 (적절): 스레드들이 줄을 서서(Queueing) 기다리지만, CPU는 해시 연산에 집중하므로 전체 처리 속도는 빠릅니다.
+         * - Pool Size 200 (과다): 200개의 스레드가 동시에 커넥션을 잡고 CPU 쟁탈전을 벌입니다. 
+         *   컨텍스트 스위칭 비용으로 인해 총 소요 시간이 오히려 더 늘어날 수 있습니다.
+         */
+    }
+}

--- a/src/test/java/talkPick/performance/MemberDeletePerformanceTest.java
+++ b/src/test/java/talkPick/performance/MemberDeletePerformanceTest.java
@@ -1,0 +1,97 @@
+package talkPick.performance;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import talkPick.domain.inquiry.adapter.out.repository.InquiryJpaRepository;
+import talkPick.domain.inquiry.domain.Inquiry;
+import talkPick.domain.inquiry.domain.type.InquiryType;
+import talkPick.domain.member.adapter.out.repository.MemberTopicHistoryJpaRepository;
+import talkPick.domain.member.adapter.out.repository.MemberTopicResultJpaRepository;
+import talkPick.domain.topic.domain.member.MemberTopicHistory;
+import talkPick.domain.topic.domain.member.MemberTopicResult;
+import talkPick.domain.topic.domain.type.TopicType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class MemberDeletePerformanceTest {
+
+    @Autowired InquiryJpaRepository inquiryRepository;
+    @Autowired MemberTopicHistoryJpaRepository historyRepository;
+    @Autowired MemberTopicResultJpaRepository resultRepository;
+    @Autowired EntityManager em;
+
+    @Test
+    @DisplayName("회원 삭제 시 쿼리 발생 횟수 비교 (기존 vs 벌크)")
+    void compareQueryCounts() {
+        Long memberId = 99999L; // 테스트용 가상 ID
+
+        // Case 1: 기존 방식 (JPA Delete)
+        setupData(memberId);
+        em.flush();
+        em.clear();
+
+        inquiryRepository.deleteByMemberId(memberId);
+        historyRepository.deleteByMemberId(memberId);
+        resultRepository.deleteByMemberId(memberId);
+        em.flush();
+
+        // Case 2: 벌크 방식 (@Modifying)
+        setupData(memberId);
+        em.flush();
+        em.clear();
+
+        inquiryRepository.deleteAllByMemberIdInBulk(memberId);
+        historyRepository.deleteAllByMemberIdInBulk(memberId);
+        resultRepository.deleteAllByMemberIdInBulk(memberId);
+    }
+
+    private void setupData(Long memberId) {
+        int count = 100; // 각 엔티티 당 100개씩 생성
+
+        // 1. Inquiry 생성
+        List<Inquiry> inquiries = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            inquiries.add(Inquiry.builder()
+                    .memberId(memberId)
+                    .title("테스트 문의 " + i)
+                    .content("내용입니다.")
+                    .email("test" + i + "@example.com")
+                    .type(InquiryType.GENERAL)
+                    .isAnswered(false)
+                    .build());
+        }
+        inquiryRepository.saveAll(inquiries);
+
+        // 2. MemberTopicHistory 생성
+        List<MemberTopicHistory> histories = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            histories.add(MemberTopicHistory.builder()
+                    .memberId(memberId)
+                    .topicId(100L + i)
+                    .talkTime(60000L)
+                    .checkLiked(false)
+                    .sequence(i)
+                    .topicType(TopicType.SELECTED)
+                    .build());
+        }
+        historyRepository.saveAll(histories);
+
+        // 3. MemberTopicResult 생성
+        List<MemberTopicResult> results = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            results.add(MemberTopicResult.builder()
+                    .memberId(memberId)
+                    .memberTopicHistoryId(200L + i)
+                    .comment("결과 코멘트 " + i)
+                    .build());
+        }
+        resultRepository.saveAll(results);
+    }
+}

--- a/src/test/java/talkPick/performance/PerformanceTestService.java
+++ b/src/test/java/talkPick/performance/PerformanceTestService.java
@@ -1,0 +1,39 @@
+package talkPick.performance;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@Service
+public class PerformanceTestService {
+
+    /**
+     * DB 커넥션을 점유한 상태(@Transactional)에서
+     * CPU 연산을 수행하여 컨텍스트 스위칭 부하를 시뮬레이션합니다.
+     */
+    @Transactional
+    public void heavyWork() {
+        try {
+            // CPU 부하를 주기 위한 해시 계산 (50,000번 반복)
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            String data = "dummy-data-for-simulation-" + System.nanoTime();
+            final Object SHARED_LOCK = new Object();
+            
+            for (int i = 0; i < 50000; i++) {
+                digest.update(data.getBytes());
+                digest.digest();
+
+                synchronized (SHARED_LOCK) {
+                    try {
+                        // 아주 짧은 락 점유
+                        Thread.sleep(1);
+                    } catch (InterruptedException e) {}
+                }
+            }
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 알고리즘을 찾을 수 없습니다.", e);
+        }
+    }
+}


### PR DESCRIPTION
## 🔥 Pull Request

⛳️ **Branch**
- fix/#257

👷 **Work Done**
- 회원 탈퇴 시 DI 위반 문제 및 성능 문제 해결을 위해 '퍼사드 패턴', '벌크 연산' 도입

## ✅ Changes

**1. 퍼사드 패턴 도입 (`MemberWithdrawalService`)**
- 기존 `MemberCommandService`가 회원 탈퇴 처리를 위해 타 도메인의 Repository를 과도하게 의존하던 문제(DI 원칙 위반, 강한 결합)를 해결했습니다.
- 연관 데이터 삭제 로직을 전담하는 `MemberWithdrawalService`를 만들어 복잡한 의존성은 캡슐화했습니다.

**2. JPQL 벌크 연산 적용**
- 기존 JPA의 기본 삭제 동작(조회 후 Loop 돌며 단건 삭제)으로 인해 발생하던 대량의 쿼리 발생 문제를 해결했습니다.
- `@Modifying`을 활용한 벌크 연산을 적용하여, N건의 데이터를 한 번의 쿼리로 삭제하도록 최적화했습니다.

## 🚨 Notes
관련해서 작성한 글입니다. 
https://velog.io/@simhyunmin/%ED%86%A0%ED%94%BD-%ED%9A%8C%EC%9B%90-%ED%83%88%ED%87%B4-%EA%B8%B0%EB%8A%A5-%EC%84%B1%EB%8A%A5-%EC%B5%9C%EC%A0%81%ED%99%94-%EB%B0%8F-%EA%B5%AC%EC%A1%B0-%EA%B0%9C%EC%84%A0

## 📟 Related Issues
- Resolved: #257 