### PR TITLE
[Refactor] 회원 삭제 소프트 방식으로 변경

### DIFF
--- a/src/main/java/talkPick/batch/member/scheduler/MemberCleanupScheduler.java
+++ b/src/main/java/talkPick/batch/member/scheduler/MemberCleanupScheduler.java
@@ -1,0 +1,50 @@
+package talkPick.batch.member.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import talkPick.domain.member.adapter.out.repository.MemberJpaRepository;
+import talkPick.domain.member.domain.Member;
+import talkPick.domain.member.port.in.MemberWithdrawalUseCase;
+import talkPick.global.model.TalkPickStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberCleanupScheduler {
+
+    private final MemberJpaRepository memberRepository;
+    private final MemberWithdrawalUseCase memberWithdrawalUseCase;
+
+    /**
+     * 매일 새벽 3시에 탈퇴한 지 15일이 지난 회원을 영구 삭제합니다.
+     */
+    @Scheduled(cron = "0 0 3 * * *")
+    public void cleanupExpiredMembers() {
+        log.info("회원 탈퇴 데이터 정리 스케줄러 시작");
+        
+        LocalDateTime thresholdDate = LocalDateTime.now().minusDays(15);
+        Optional<Member> expiredMember = memberRepository.findTop1ByStatusAndDeletedAtBefore(TalkPickStatus.DIS_ACTIVE, thresholdDate);
+
+        if (expiredMember.isPresent()) {
+            Member member = expiredMember.get();
+            try {
+                log.info("삭제 대상 회원 ID: {}", member.getId());
+                memberWithdrawalUseCase.hardDelete(member.getId());
+                log.info("회원 ID {} 영구 삭제 완료", member.getId());
+            } catch (Exception e) {
+                log.error("회원 ID {} 영구 삭제 중 오류 발생", member.getId(), e);
+            }
+        } else {
+            log.info("삭제 대상 회원이 없습니다.");
+        }
+
+        log.info("회원 탈퇴 데이터 정리 스케줄러 종료");
+    }
+}

--- a/src/main/java/talkPick/domain/member/adapter/in/MemberCommandApi.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/MemberCommandApi.java
@@ -21,6 +21,12 @@ public interface MemberCommandApi {
     @Operation(summary = "APPLE Oauth2 로그인 API", description = "APPLE OAuth2 로그인 API 입니다.")
     JwtResDTO.Login appleOauth2Login (@Valid @RequestBody MemberReqDto.OAuth2LoginRequest request, HttpServletResponse response);
 
+    @PostMapping("/{provider}/reactivate")
+    @Operation(summary = "계정 복구 API", description = "탈퇴한 계정(kakao/apple)을 복구하고 로그인합니다. provider: 'kakao' 또는 'apple'")
+    JwtResDTO.Login reactivateMember(
+            @Parameter(description = "kakao 또는 apple", example = "kakao") @PathVariable("provider") String provider,
+            @Valid @RequestBody MemberReqDto.OAuth2LoginRequest request, HttpServletResponse response);
+
     @PostMapping("/token/refresh")
     @Operation(summary = "액세스 토큰 재발급", description = "쿠키에 담긴 리프레시 토큰으로 액세스 토큰을 재발급합니다.")
     JwtResDTO.AccessToken refreshAccessToken(

--- a/src/main/java/talkPick/domain/member/adapter/in/MemberCommandController.java
+++ b/src/main/java/talkPick/domain/member/adapter/in/MemberCommandController.java
@@ -66,6 +66,37 @@ public class MemberCommandController implements MemberCommandApi {
         );
     }
 
+    @Override
+    public JwtResDTO.Login reactivateMember(
+            @PathVariable("provider") String provider,
+            @Valid @RequestBody MemberReqDto.OAuth2LoginRequest request, HttpServletResponse response
+    ) {
+        MemberDataDto.MemberData memberData;
+        LoginType loginType;
+
+        if ("kakao".equalsIgnoreCase(provider)) {
+            memberData = kakaoOidcService.verifyAndParseIdToken(request);
+            loginType = LoginType.KAKAO;
+        } else if ("apple".equalsIgnoreCase(provider)) {
+            memberData = appleOidcService.verifyAndParseIdToken(request);
+            loginType = LoginType.APPLE;
+        } else {
+            throw new IllegalArgumentException("지원하지 않는 Provider입니다: " + provider);
+        }
+
+        Member member = memberCommandUseCase.reactivateMember(memberData, loginType);
+        JwtResDTO.GeneratedTokens generatedTokens = jwtTokenCommandUseCase.generateToken(member);
+
+        setRefreshTokenCookie(response, generatedTokens.refreshToken(), generatedTokens.refreshExpiredTime());
+
+        return JwtResDTO.Login.of(
+                member.getId(),
+                member.getMemberRole().toString(),
+                generatedTokens.accessToken(),
+                generatedTokens.accessExpiredTime()
+        );
+    }
+
     // refresh token을 HttpOnly 쿠키로 설정하는 헬퍼 메서드
     private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken, Long refreshExpiredTime) {
         Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);

--- a/src/main/java/talkPick/domain/member/adapter/out/repository/MemberJpaRepository.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/repository/MemberJpaRepository.java
@@ -2,10 +2,15 @@ package talkPick.domain.member.adapter.out.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import talkPick.domain.member.domain.Member;
+import talkPick.global.model.TalkPickStatus;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberJpaRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByProviderId(String sub);
     Optional<Member> findByEmail(String email);
+    Optional<Member> findTop1ByStatusAndDeletedAtBefore(TalkPickStatus status, LocalDateTime dateTime);
+    List<Member> findByStatusAndDeletedAtBefore(TalkPickStatus status, LocalDateTime dateTime);
 }

--- a/src/main/java/talkPick/domain/member/application/MemberCommandService.java
+++ b/src/main/java/talkPick/domain/member/application/MemberCommandService.java
@@ -72,7 +72,28 @@ public class MemberCommandService implements MemberCommandUseCase {
     public Member findOrCreateMember(MemberDataDto.MemberData MemberData, LoginType loginType) {
         Member findOrNewMember = memberCommandRepositoryPort.findByProviderId(MemberData.getSub())
                 .orElseGet(() -> MemberConverter.toMember(MemberData, loginType));
+
+        if (findOrNewMember.getStatus() == TalkPickStatus.DIS_ACTIVE) {
+            throw new MemberExceptionHandler(ErrorCode.MEMBER_IS_WITHDRAWN);
+        }
+
         return memberCommandRepositoryPort.save(findOrNewMember);
+    }
+
+    /**
+     * 탈퇴한 회원 복구
+     */
+    @Override
+    public Member reactivateMember(MemberDataDto.MemberData memberData, LoginType loginType) {
+        Member member = memberCommandRepositoryPort.findByProviderId(memberData.getSub())
+                .orElseThrow(() -> new MemberExceptionHandler(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (member.getStatus() == TalkPickStatus.DIS_ACTIVE) {
+            member.reactivate();
+            return memberCommandRepositoryPort.save(member);
+        }
+
+        return member;
     }
 
     /**

--- a/src/main/java/talkPick/domain/member/application/MemberWithdrawalService.java
+++ b/src/main/java/talkPick/domain/member/application/MemberWithdrawalService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import talkPick.domain.inquiry.adapter.out.repository.InquiryJpaRepository;
 import talkPick.domain.member.adapter.out.repository.MemberJpaRepository;
+import talkPick.domain.member.domain.Member;
 import talkPick.domain.member.adapter.out.repository.MemberLoginHistoryJpaRepository;
 import talkPick.domain.member.adapter.out.repository.MemberTermJpaRepository;
 import talkPick.domain.member.adapter.out.repository.MemberTopicHistoryJpaRepository;
@@ -41,10 +42,21 @@ public class MemberWithdrawalService implements MemberWithdrawalUseCase {
     public void withdraw(String authorization) {
         Long memberId = jwtProvider.getMemberId(authorization);
 
-        // 1. Refresh Token 삭제
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        // 1. Refresh Token 삭제 (즉시 로그아웃 효과)
         refreshTokenRepository.deleteAllByMemberIdInBulk(memberId);
 
-        // 2. 연관 데이터 일괄 삭제
+        // 2. 소프트 삭제 처리
+        member.withdraw();
+        memberRepository.save(member);
+    }
+
+    @Override
+    @Transactional
+    public void hardDelete(Long memberId) {
+        // 1. 연관 데이터 일괄 삭제
         inquiryRepository.deleteAllByMemberIdInBulk(memberId);
         memberTermRepository.deleteAllByMemberIdInBulk(memberId);
         memberLoginHistoryRepository.deleteAllByMemberIdInBulk(memberId);
@@ -55,7 +67,7 @@ public class MemberWithdrawalService implements MemberWithdrawalUseCase {
         todayTopicRepository.deleteAllByMemberIdInBulk(memberId);
         topicLikeHistoryRepository.deleteAllByMemberIdInBulk(memberId);
 
-        // 3. 회원 삭제
+        // 2. 회원 영구 삭제
         memberRepository.deleteById(memberId);
     }
 }

--- a/src/main/java/talkPick/domain/member/domain/Member.java
+++ b/src/main/java/talkPick/domain/member/domain/Member.java
@@ -10,6 +10,7 @@ import talkPick.global.model.BaseTime;
 import talkPick.global.model.TalkPickStatus;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -82,6 +83,11 @@ public class Member extends BaseTime {
     )
     private String providerId;
 
+    @Column(
+            columnDefinition = "DATETIME COMMENT '회원 탈퇴 일시'"
+    )
+    private LocalDateTime deletedAt;
+
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
@@ -92,6 +98,16 @@ public class Member extends BaseTime {
 
     public void updatePassword(String password) {
         this.password = password;
+    }
+
+    public void withdraw() {
+        this.status = TalkPickStatus.DIS_ACTIVE;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public void reactivate() {
+        this.status = TalkPickStatus.ACTIVE;
+        this.deletedAt = null;
     }
 
 }

--- a/src/main/java/talkPick/domain/member/port/in/MemberCommandUseCase.java
+++ b/src/main/java/talkPick/domain/member/port/in/MemberCommandUseCase.java
@@ -9,6 +9,7 @@ import talkPick.domain.member.adapter.out.dto.MemberResDto;
 public interface MemberCommandUseCase {
     MemberResDto.MemberProfileResponse updateProfile(String authorization, MemberReqDto.ProfileUpdateRequest request);
     Member findOrCreateMember(MemberDataDto.MemberData kakaoMemberData, LoginType loginType);
+    Member reactivateMember(MemberDataDto.MemberData memberData, LoginType loginType);
     MemberResDto.MemberSignupResponse memberSignup(String authorization, MemberReqDto.MemberSignupRequest request);
     MemberResDto.TermAgreementResponse termAgreement(String authorization, MemberReqDto.TermAgreementRequest request);
     void logout(String authorization);

--- a/src/main/java/talkPick/domain/member/port/in/MemberWithdrawalUseCase.java
+++ b/src/main/java/talkPick/domain/member/port/in/MemberWithdrawalUseCase.java
@@ -2,4 +2,5 @@ package talkPick.domain.member.port.in;
 
 public interface MemberWithdrawalUseCase {
     void withdraw(String authorization);
+    void hardDelete(Long memberId);
 }

--- a/src/main/java/talkPick/global/config/SchedulingConfig.java
+++ b/src/main/java/talkPick/global/config/SchedulingConfig.java
@@ -1,0 +1,20 @@
+package talkPick.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulingConfig implements SchedulingConfigurer {
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(3);
+        taskScheduler.setThreadNamePrefix("scheduled-task-");
+        taskScheduler.initialize();
+
+        taskRegistrar.setTaskScheduler(taskScheduler);
+    }
+}

--- a/src/main/java/talkPick/global/exception/ErrorCode.java
+++ b/src/main/java/talkPick/global/exception/ErrorCode.java
@@ -70,6 +70,7 @@ public enum ErrorCode {
 
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    MEMBER_IS_WITHDRAWN(HttpStatus.FORBIDDEN, "탈퇴한 회원입니다."),
     MEMBER_EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
     INVALID_MEMBER_INFO(HttpStatus.BAD_REQUEST, "회원 필수 정보가 누락되었습니다."),
     PASSWORD_REQUIRED(HttpStatus.BAD_REQUEST, "비밀번호는 필수입니다."),

--- a/src/main/java/talkPick/global/security/model/WhiteList.java
+++ b/src/main/java/talkPick/global/security/model/WhiteList.java
@@ -8,6 +8,8 @@ public final class WhiteList {
             "/api/v1/admin/login",
             "/api/v1/members/kakao/login",
             "/api/v1/members/apple/login",
+            "/api/v1/members/kakao/reactivate",
+            "/api/v1/members/apple/reactivate",
             "/api/v1/members/token/refresh",
             "/api/v1/inquiry",
             "/swagger-ui/**",


### PR DESCRIPTION
## 🔥 Pull Request

⛳️ **Branch**
- refactor/#267

👷 **Work Done**
- 회원 삭제 방식 소프트 삭제 방식으로 변경 및 계정 복구 API 추가
## ✅ Changes
- 회원 삭제를 위한 스케줄러 추가
  - 15일 이전에 삭제된 계정 하드 삭제
- 현재 프로젝트 내 스케줄러가 여러개 존재하기 때문에 이를 위한 스케줄 설정 클래스 생성
  - 스케줄러를 위한 스레드 풀 2개로 설정 (기본은 1개)
- 계정 복구 API 추가 ("/api/v1/members/{provider}/reactivate")

## 🚨 Notes
<!-- 리뷰 시 참고해야 할 내용, 고려사항 기입 -->

## 📟 Related Issues
- Resolved: #267 