### PR TITLE
[Feature] 좋아요 API 토글 기능으로 변경

### DIFF
--- a/src/main/java/talkPick/domain/member/adapter/out/repository/MemberLikedTopicsQuerydslRepository.java
+++ b/src/main/java/talkPick/domain/member/adapter/out/repository/MemberLikedTopicsQuerydslRepository.java
@@ -12,6 +12,7 @@ import talkPick.domain.topic.domain.QKeyword;
 import talkPick.domain.topic.domain.QTopic;
 import talkPick.domain.topic.domain.QCategory;
 import talkPick.domain.topic.domain.QTopicLikeHistory;
+import talkPick.global.model.TalkPickStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -30,7 +31,9 @@ public class MemberLikedTopicsQuerydslRepository implements MemberLikedTopicsQue
 
         // 기본 조건: 특정 회원이 좋아요한 토픽만 조회
         BooleanBuilder builder = new BooleanBuilder()
-                .and(tlh.memberId.eq(member.getId()));
+                .and(tlh.memberId.eq(member.getId()))
+                .and(tlh.status.eq(TalkPickStatus.ACTIVE)
+                );
 
         // 커서 기반 페이징 조건 추가
         // cursor가 null이 아닌 경우, 해당 시간보다 이전(더 오래된) 데이터만 조회

--- a/src/main/java/talkPick/domain/topic/adapter/in/TopicCommandController.java
+++ b/src/main/java/talkPick/domain/topic/adapter/in/TopicCommandController.java
@@ -11,6 +11,6 @@ public class TopicCommandController implements TopicCommandApi {
 
     @Override
     public void addLike(final Long memberId, final Long topicId) {
-        topicCommandUseCase.addLike(memberId, topicId);
+        topicCommandUseCase.toggleLike(memberId, topicId);
     }
 }

--- a/src/main/java/talkPick/domain/topic/adapter/out/TopicLikeHistoryCommandRepositoryAdapter.java
+++ b/src/main/java/talkPick/domain/topic/adapter/out/TopicLikeHistoryCommandRepositoryAdapter.java
@@ -22,5 +22,10 @@ public class TopicLikeHistoryCommandRepositoryAdapter implements TopicLikeHistor
             throw new TopicExceptionHandler(ErrorCode.DUPLICATE_LIKE);
         }
     }
+
+    @Override
+    public void delete(TopicLikeHistory topicLikeHistory) {
+        topicLikeHistory.delete();
+    }
 }
 

--- a/src/main/java/talkPick/domain/topic/adapter/out/TopicLikeHistoryQueryRepositoryAdapter.java
+++ b/src/main/java/talkPick/domain/topic/adapter/out/TopicLikeHistoryQueryRepositoryAdapter.java
@@ -1,0 +1,21 @@
+package talkPick.domain.topic.adapter.out;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import talkPick.domain.topic.adapter.out.repository.TopicLikeHistoryJpaRepository;
+import talkPick.domain.topic.domain.TopicLikeHistory;
+import talkPick.domain.topic.port.out.TopicLikeHistoryQueryRepositoryPort;
+import talkPick.global.model.TalkPickStatus;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class TopicLikeHistoryQueryRepositoryAdapter implements TopicLikeHistoryQueryRepositoryPort {
+    private final TopicLikeHistoryJpaRepository topicLikeHistoryJpaRepository;
+
+    @Override
+    public Optional<TopicLikeHistory> findActiveHistory(final Long memberId, final Long topicId) {
+        return topicLikeHistoryJpaRepository.findFirstByMemberIdAndTopicIdAndStatusOrderByIdDesc(memberId, topicId, TalkPickStatus.ACTIVE);
+    }
+}
+

--- a/src/main/java/talkPick/domain/topic/adapter/out/repository/TopicLikeHistoryJpaRepository.java
+++ b/src/main/java/talkPick/domain/topic/adapter/out/repository/TopicLikeHistoryJpaRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import talkPick.domain.topic.domain.TopicLikeHistory;
+import talkPick.global.model.TalkPickStatus;
+
+import java.util.Optional;
 
 public interface TopicLikeHistoryJpaRepository extends JpaRepository<TopicLikeHistory, Long> {
     void deleteByMemberId(Long memberId);
@@ -12,4 +15,8 @@ public interface TopicLikeHistoryJpaRepository extends JpaRepository<TopicLikeHi
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM TopicLikeHistory t WHERE t.memberId = :memberId")
     void deleteAllByMemberIdInBulk(@Param("memberId") Long memberId);
+
+    Optional<TopicLikeHistory> findFirstByMemberIdAndTopicIdAndStatusOrderByIdDesc(
+            Long memberId, Long topicId, TalkPickStatus status
+    );
 }

--- a/src/main/java/talkPick/domain/topic/application/TopicCommandService.java
+++ b/src/main/java/talkPick/domain/topic/application/TopicCommandService.java
@@ -4,21 +4,34 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import talkPick.domain.topic.domain.TopicLikeHistory;
 import talkPick.domain.topic.domain.event.TopicLikedEvent;
 import talkPick.domain.topic.port.in.TopicCommandUseCase;
 import talkPick.domain.topic.port.out.TopicLikeHistoryCommandRepositoryPort;
+import talkPick.domain.topic.port.out.TopicLikeHistoryQueryRepositoryPort;
+import talkPick.global.model.TalkPickStatus;
 import talkPick.global.security.annotation.MemberId;
+
+import java.util.Optional;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class TopicCommandService implements TopicCommandUseCase {
     private final TopicLikeHistoryCommandRepositoryPort topicLikeHistoryCommandRepositoryPort;
+    private final TopicLikeHistoryQueryRepositoryPort topicLikeHistoryQueryRepositoryPort;
     private final ApplicationEventPublisher eventPublisher;
 
     @Override
-    public void addLike(@MemberId Long memberId, Long topicId) {
-        topicLikeHistoryCommandRepositoryPort.save(memberId, topicId);
-        eventPublisher.publishEvent(TopicLikedEvent.of(this, memberId, topicId));
+    public void toggleLike(Long memberId, Long topicId) {
+        Optional<TopicLikeHistory> activeHistory = topicLikeHistoryQueryRepositoryPort
+                .findActiveHistory(memberId, topicId);
+
+        if (activeHistory.isPresent()) {
+            topicLikeHistoryCommandRepositoryPort.delete(activeHistory.get());
+        } else {
+            topicLikeHistoryCommandRepositoryPort.save(memberId, topicId);
+            eventPublisher.publishEvent(TopicLikedEvent.of(this, memberId, topicId));
+        }
     }
 }

--- a/src/main/java/talkPick/domain/topic/domain/TopicLikeHistory.java
+++ b/src/main/java/talkPick/domain/topic/domain/TopicLikeHistory.java
@@ -11,10 +11,7 @@ import talkPick.global.model.TalkPickStatus;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
-        name = "topic_like_history",
-        uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"memberId", "topicId"})
-        }
+        name = "topic_like_history"
 )
 public class TopicLikeHistory extends BaseTime {
     @Id
@@ -38,5 +35,9 @@ public class TopicLikeHistory extends BaseTime {
                 .memberId(memberId)
                 .topicId(topicId)
                 .build();
+    }
+
+    public void delete() {
+        this.status = TalkPickStatus.DIS_ACTIVE;
     }
 }

--- a/src/main/java/talkPick/domain/topic/port/in/TopicCommandUseCase.java
+++ b/src/main/java/talkPick/domain/topic/port/in/TopicCommandUseCase.java
@@ -1,7 +1,5 @@
 package talkPick.domain.topic.port.in;
 
-import talkPick.global.security.annotation.MemberId;
-
 public interface TopicCommandUseCase {
-    void addLike(@MemberId Long memberId, Long topicId);
+    void toggleLike(Long memberId, Long topicId);
 }

--- a/src/main/java/talkPick/domain/topic/port/out/TopicLikeHistoryCommandRepositoryPort.java
+++ b/src/main/java/talkPick/domain/topic/port/out/TopicLikeHistoryCommandRepositoryPort.java
@@ -1,5 +1,8 @@
 package talkPick.domain.topic.port.out;
 
+import talkPick.domain.topic.domain.TopicLikeHistory;
+
 public interface TopicLikeHistoryCommandRepositoryPort {
     void save(final Long memberId, final Long topicId);
+    void delete(TopicLikeHistory topicLikeHistory);
 }

--- a/src/main/java/talkPick/domain/topic/port/out/TopicLikeHistoryQueryRepositoryPort.java
+++ b/src/main/java/talkPick/domain/topic/port/out/TopicLikeHistoryQueryRepositoryPort.java
@@ -1,0 +1,9 @@
+package talkPick.domain.topic.port.out;
+
+import talkPick.domain.topic.domain.TopicLikeHistory;
+
+import java.util.Optional;
+
+public interface TopicLikeHistoryQueryRepositoryPort {
+    Optional<TopicLikeHistory> findActiveHistory(final Long memberId, final Long topicId);
+}

--- a/src/main/java/talkPick/global/exception/ErrorCode.java
+++ b/src/main/java/talkPick/global/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     KEYWORD_NOT_FOUND(HttpStatus.BAD_REQUEST,"찾을 수 없는 키워드입니다."),
     ADD_LIKE_FAIL(HttpStatus.BAD_REQUEST,"토픽 좋아요 실패했습니다."),
     DUPLICATE_LIKE(HttpStatus.BAD_REQUEST,"이미 좋아요 눌렀습니다."),
+    TOPIC_LIKE_HISTORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "찾을 수 없는 토픽 좋아요 기록입니다."),
 
     // Random
     TOPIC_STAT_NOT_FOUND(HttpStatus.BAD_REQUEST,"찾을 수 없는 토픽 통계입니다."),

--- a/src/test/java/talkPick/topic/application/TopicCommandServiceTest.java
+++ b/src/test/java/talkPick/topic/application/TopicCommandServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import talkPick.domain.topic.application.TopicCommandService;
+import talkPick.domain.topic.domain.TopicLikeHistory;
 import talkPick.domain.topic.domain.event.TopicLikedEvent;
 import talkPick.domain.topic.port.out.TopicLikeHistoryCommandRepositoryPort;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,6 +18,9 @@ import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.*;
 import org.mockito.ArgumentCaptor;
+import talkPick.domain.topic.port.out.TopicLikeHistoryQueryRepositoryPort;
+
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("TopicCommandService 테스트")
@@ -29,17 +33,20 @@ class TopicCommandServiceTest {
     private TopicLikeHistoryCommandRepositoryPort topicLikeHistoryCommandRepositoryPort;
 
     @Mock
+    private TopicLikeHistoryQueryRepositoryPort topicLikeHistoryQueryRepositoryPort;
+
+    @Mock
     private ApplicationEventPublisher eventPublisher;
 
     @Test
-    @DisplayName("토픽 좋아요 추가 및 이벤트 발행 테스트")
-    void 토픽_좋아요_추가_및_이벤트_발행_테스트() {
+    @DisplayName("최초 좋아요 시 기록이 없으면 신규 저장하고 이벤트를 발행한다")
+    void 최초_좋아요_테스트() {
         // given
         Long memberId = 1L;
         Long topicId = 100L;
 
-        willDoNothing().given(topicLikeHistoryCommandRepositoryPort).save(memberId, topicId);
-        willDoNothing().given(eventPublisher).publishEvent(any(TopicLikedEvent.class));
+        when(topicLikeHistoryQueryRepositoryPort.findActiveHistory(memberId, topicId))
+                .thenReturn(Optional.empty());
 
         // when
         topicCommandService.toggleLike(memberId, topicId);
@@ -47,67 +54,51 @@ class TopicCommandServiceTest {
         // then
         verify(topicLikeHistoryCommandRepositoryPort, times(1)).save(memberId, topicId);
         verify(eventPublisher, times(1)).publishEvent(any(TopicLikedEvent.class));
+        verify(topicLikeHistoryCommandRepositoryPort, never()).delete(any());
     }
 
     @Test
-    @DisplayName("토픽 좋아요 추가 시 Repository 저장 후 이벤트 발행 순서 확인 테스트")
-    void 토픽_좋아요_추가시_Repository_저장_후_이벤트_발행_순서_확인_테스트() {
+    @DisplayName("이미 좋아요가 되어 있으면 기록을 비활성화(삭제)하고 이벤트를 발행하지 않는다")
+    void 좋아요_취소_테스트() {
         // given
         Long memberId = 1L;
         Long topicId = 100L;
+        TopicLikeHistory existingHistory = spy(TopicLikeHistory.of(memberId, topicId));
 
-        willDoNothing().given(topicLikeHistoryCommandRepositoryPort).save(memberId, topicId);
-        willDoNothing().given(eventPublisher).publishEvent(any(TopicLikedEvent.class));
+        // ACTIVE한 기록이 이미 존재하는 상황 가정
+        when(topicLikeHistoryQueryRepositoryPort.findActiveHistory(memberId, topicId))
+                .thenReturn(Optional.of(existingHistory));
 
         // when
         topicCommandService.toggleLike(memberId, topicId);
 
         // then
-        var inOrder = org.mockito.Mockito.inOrder(topicLikeHistoryCommandRepositoryPort, eventPublisher);
-        inOrder.verify(topicLikeHistoryCommandRepositoryPort).save(memberId, topicId);
-        inOrder.verify(eventPublisher).publishEvent(any(TopicLikedEvent.class));
+        verify(topicLikeHistoryCommandRepositoryPort, times(1)).delete(existingHistory);
+        verify(topicLikeHistoryCommandRepositoryPort, never()).save(anyLong(), anyLong());
+        verify(eventPublisher, never()).publishEvent(any(TopicLikedEvent.class));
     }
 
     @Test
-    @DisplayName("토픽 좋아요 추가 시 ArgumentCaptor로 이벤트 내용 검증 테스트")
-    void 토픽_좋아요_추가시_ArgumentCaptor로_이벤트_내용_검증_테스트() {
+    @DisplayName("좋아요 시 ArgumentCaptor로 발행된 이벤트의 필드를 검증한다")
+    void 이벤트_내용_검증_테스트() {
         // given
         Long memberId = 1L;
         Long topicId = 100L;
         ArgumentCaptor<TopicLikedEvent> eventCaptor = ArgumentCaptor.forClass(TopicLikedEvent.class);
 
-        willDoNothing().given(topicLikeHistoryCommandRepositoryPort).save(memberId, topicId);
-        willDoNothing().given(eventPublisher).publishEvent(any(TopicLikedEvent.class));
+        when(topicLikeHistoryQueryRepositoryPort.findActiveHistory(memberId, topicId))
+                .thenReturn(Optional.empty());
 
         // when
         topicCommandService.toggleLike(memberId, topicId);
 
         // then
-        verify(topicLikeHistoryCommandRepositoryPort).save(memberId, topicId);
         verify(eventPublisher).publishEvent(eventCaptor.capture());
-
         TopicLikedEvent capturedEvent = eventCaptor.getValue();
+
         assertAll(
-                () -> assertThat(capturedEvent).isNotNull(),
                 () -> assertThat(capturedEvent.getMemberId()).isEqualTo(memberId),
                 () -> assertThat(capturedEvent.getTopicId()).isEqualTo(topicId)
         );
-    }
-
-    @Test
-    @DisplayName("토픽 좋아요 추가 시 Repository 예외 발생 테스트")
-    void 토픽_좋아요_추가시_Repository_예외_발생_테스트() {
-        // given
-        Long memberId = 1L;
-        Long topicId = 100L;
-
-        willThrow(new IllegalStateException("Already liked"))
-                .given(topicLikeHistoryCommandRepositoryPort).save(memberId, topicId);
-
-        // when & then
-        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
-                () -> topicCommandService.toggleLike(memberId, topicId));
-
-        verify(eventPublisher, never()).publishEvent(any(TopicLikedEvent.class));
     }
 }

--- a/src/test/java/talkPick/topic/application/TopicCommandServiceTest.java
+++ b/src/test/java/talkPick/topic/application/TopicCommandServiceTest.java
@@ -42,7 +42,7 @@ class TopicCommandServiceTest {
         willDoNothing().given(eventPublisher).publishEvent(any(TopicLikedEvent.class));
 
         // when
-        topicCommandService.addLike(memberId, topicId);
+        topicCommandService.toggleLike(memberId, topicId);
 
         // then
         verify(topicLikeHistoryCommandRepositoryPort, times(1)).save(memberId, topicId);
@@ -60,7 +60,7 @@ class TopicCommandServiceTest {
         willDoNothing().given(eventPublisher).publishEvent(any(TopicLikedEvent.class));
 
         // when
-        topicCommandService.addLike(memberId, topicId);
+        topicCommandService.toggleLike(memberId, topicId);
 
         // then
         var inOrder = org.mockito.Mockito.inOrder(topicLikeHistoryCommandRepositoryPort, eventPublisher);
@@ -80,7 +80,7 @@ class TopicCommandServiceTest {
         willDoNothing().given(eventPublisher).publishEvent(any(TopicLikedEvent.class));
 
         // when
-        topicCommandService.addLike(memberId, topicId);
+        topicCommandService.toggleLike(memberId, topicId);
 
         // then
         verify(topicLikeHistoryCommandRepositoryPort).save(memberId, topicId);
@@ -106,7 +106,7 @@ class TopicCommandServiceTest {
 
         // when & then
         org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
-                () -> topicCommandService.addLike(memberId, topicId));
+                () -> topicCommandService.toggleLike(memberId, topicId));
 
         verify(eventPublisher, never()).publishEvent(any(TopicLikedEvent.class));
     }


### PR DESCRIPTION
## 🔥 Pull Request

⛳️ **Branch**
- feature/#296

👷 **Work Done**
<!-- 무엇을 작업했는지 요약해주세요. -->
- 좋아요 API 변경
- 사용자 좋아요 톡픽 목록 조회 API 확인
- 테스트 코드 수정

## ✅ Changes
<!-- 주요 변경 사항 (신규 기능, 리팩토링, 버그 수정 등) -->

## 🚨 Notes
<!-- 리뷰 시 참고해야 할 내용, 고려사항 기입 -->

## 📟 Related Issues
- Resolved: #296 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 토픽 좋아요가 토글 방식으로 변경되어 사용자가 한 번의 조작으로 좋아요 추가/취소를 할 수 있습니다.
* **버그 수정 / 개선**
  * 좋아요 조회 시 활성 상태만 반환하도록 필터링되어 목록이 더 정확해졌습니다.
  * 존재하지 않는 좋아요 기록에 대해 명확한 오류 메시지가 추가되어 실패 원인을 알기 쉬워졌습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->